### PR TITLE
Check settings exists before hooking for sync

### DIFF
--- a/inc/class-s3-media-sync.php
+++ b/inc/class-s3-media-sync.php
@@ -43,9 +43,11 @@ class S3_Media_Sync {
 		add_action( 'admin_menu', [ $this, 'register_menu_settings' ] );
 		add_action( 'admin_init', [ $this, 'settings_screeen_init' ] );
 
-		// Perform on-the-fly media syncs by hooking into these actions
-		add_action( 'add_attachment', [ $this, 'add_attachment_to_s3' ], 10, 1 );
-		add_action( 'delete_attachment', [ $this, 'delete_attachment_from_s3' ], 10, 1 );
+		if ( ! empty( $this->settings ) ) {
+			// Perform on-the-fly media syncs by hooking into these actions
+			add_action( 'add_attachment', [ $this, 'add_attachment_to_s3' ], 10, 1 );
+			add_action( 'delete_attachment', [ $this, 'delete_attachment_from_s3' ], 10, 1 );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes fatal error on deleting an attachment when plugin is activated without settings in place.

```
PHP Fatal error:  Uncaught InvalidArgumentException: Missing required client configuration options: 
region: (string)
  A "region" configuration value is required for the "s3" service
  (e.g., "us-west-2"). A list of available public regions and endpoints can be
  found at http://docs.aws.amazon.com/general/latest/gr/rande.html. in /wp-content/plugins/s3-media-sync/vendor/aws/aws-sdk-php/src/ClientResolver.php:387
Stack trace:
#0 /wp-content/plugins/s3-media-sync/vendor/aws/aws-sdk-php/src/ClientResolver.php(283): Aws\ClientResolver->throwRequired(Array)
#1 wp-content/plugins/s3-media-sync/vendor/aws/aws-sdk-php/src/AwsClient.php(174): Aws\ClientResolver->resolve(Array, Object(Aws\HandlerList))
#2 wp-content/plugins/s3-media-sync/vendor/aws/aws-sdk-php/src/S3/S3Client.php(283): Aws\AwsClient->__construc in /wp-content/plugins/s3-media-sync/vendor/aws/aws-sdk-php/src/ClientResolver.php on line 387
```