### PR TITLE
Update `aws-sdk-php` version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,6 @@
     "type": "wordpress-plugin",
     "require": {
         "composer/installers": "~1.0",
-        "aws/aws-sdk-php": "~3.18"
+        "aws/aws-sdk-php": "~3.150.1"
     }
 }


### PR DESCRIPTION
Plugin currently uses `aws-sdk-php` version 3.18, which is quite outdated.  Update to see if the latest version solves the zero-byte upload issue.  Needs testing.