### PR TITLE
Add/upload image edits to s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ wp vip migration validate-attachments invalid-attachments.csv --url=example-site
 The log is then available at `invalid-attachments.csv`. The full command can be found here:
 
 https://github.com/Automattic/vip-go-mu-plugins/blob/master/wp-cli/vip-migrations.php#L165-L187
+
+
+## Changelog
+
+### 1.1.0
+- Fix: Upload images edited within WordPress to the bucket.

--- a/s3-media-sync.php
+++ b/s3-media-sync.php
@@ -5,7 +5,7 @@
  * Author: Alexis Kulash, WordPress VIP
  * Text Domain: s3-media-sync
  * Domain Path: /languages/
- * Version: 1.0.0
+ * Version: 1.1.0
  */
 
 /**


### PR DESCRIPTION
This hooks into the [`wp_save_image_editor_file` action](https://developer.wordpress.org/reference/hooks/wp_save_image_editor_file/) to save the image early, so we can copy it to the S3 bucket.

[WordPress doesn't provide an action hook after saving an edited image](https://github.com/WordPress/WordPress/blob/982c3891251045e1590c9549b9296932078d4d43/wp-admin/includes/image-edit.php#L352-L358), so we need to hook into `wp_save_image_editor_file` so we can save the file, upload it to the S3 bucket, and return the result of the save.