### PR TITLE
Adding `upload` method for single attachment ID upload

### DIFF
--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -4,57 +4,57 @@ use \WP_CLI\Utils;
 
 class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 
-	/**
-	 * Upload a single attachment to S3
-	 *
-	 * @synopsis <attachment_id>
-	 */
+    	/**
+	* Upload a single attachment to S3
+	*
+	* @synopsis <attachment_id>
+	*/
 	public function upload( $args, $assoc_args ) {
-	    $attachment_id = intval( $args[0] );
+		$attachment_id = intval( $args[0] );
 	
-	    if ( $attachment_id <= 0 ) {
-	        WP_CLI::error( 'Invalid attachment ID.' );
-	    }
+		if ( $attachment_id <= 0 ) {
+			WP_CLI::error( 'Invalid attachment ID.' );
+		}
 	
-	    $url = wp_get_attachment_url( $attachment_id );
+		$url = wp_get_attachment_url( $attachment_id );
 	
-	    if ( empty( $url ) ) {
-	        WP_CLI::error( 'Failed to retrieve attachment URL for ID: ' . $attachment_id );
-	    }
+		if ( empty( $url ) ) {
+		    WP_CLI::error( 'Failed to retrieve attachment URL for ID: ' . $attachment_id );
+		}
 	
-	    // By switching the URLs from http:// to https:// we save a request, since it will be redirected to the SSL url
-	    if ( is_ssl() ) {
-	        $url = str_replace( 'http://', 'https://', $url );
-	    }
+		// By switching the URLs from http:// to https:// we save a request, since it will be redirected to the SSL url
+		if ( is_ssl() ) {
+			$url = str_replace( 'http://', 'https://', $url );
+		}
 	
-	    $ch = curl_init();
-	    curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
-	    curl_setopt( $ch, CURLOPT_URL, $url );
-	    curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, true );
-	    curl_setopt( $ch, CURLOPT_NOBODY, true );
+		$ch = curl_init();
+		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+		curl_setopt( $ch, CURLOPT_URL, $url );
+		curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, true );
+		curl_setopt( $ch, CURLOPT_NOBODY, true );
 	
-	    // Check for errors before setting options
-	    if (curl_errno($ch)) {
-	        WP_CLI::error( 'cURL error for Attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
-	    }
+		// Check for errors before setting options
+		if (curl_errno($ch)) {
+			WP_CLI::error( 'cURL error for Attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
+		}
 	
-	    $response = curl_exec( $ch );
-	    
-	    // Check for errors after executing cURL request
-	    if (curl_errno($ch)) {
-	        WP_CLI::error( 'cURL error for Attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
-	    }
+		$response = curl_exec( $ch );
+		
+		// Check for errors after executing cURL request
+		if (curl_errno($ch)) {
+			WP_CLI::error( 'cURL error for Attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
+		}
 	
-	    $response_code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
-	    curl_close( $ch );
+		$response_code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+		curl_close( $ch );
 	
-	    if ( 200 === $response_code ) {
-	        // Process the response and upload the attachment to S3
-	        // ...
-	        WP_CLI::success( 'Attachment ID ' . $attachment_id . ' successfully uploaded to S3.' );
-	    } else {
-	        WP_CLI::error( 'Failed to fetch attachment from URL for Attachment ID ' . $attachment_id . ': ' . $url );
-	    }
+		if ( 200 === $response_code ) {
+			// Process the response and upload the attachment to S3
+			// ...
+			WP_CLI::success( 'Attachment ID ' . $attachment_id . ' successfully uploaded to S3.' );
+		} else {
+			WP_CLI::error( 'Failed to fetch attachment from URL for Attachment ID ' . $attachment_id . ': ' . $url );
+		}
 	}
 	
 	/**

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -38,7 +38,7 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 		curl_setopt( $ch, CURLOPT_NOBODY, true );
 	
 		// Check for errors before setting options
-		if (curl_errno($ch)) {
+		if ( curl_errno( $ch ) ) {
 			WP_CLI::error( 'cURL error for attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
 		}
 	

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -5,6 +5,59 @@ use \WP_CLI\Utils;
 class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 
 	/**
+	 * Upload a single attachment to S3
+	 *
+	 * @synopsis <attachment_id>
+	 */
+	public function upload( $args, $assoc_args ) {
+	    $attachment_id = intval( $args[0] );
+	
+	    if ( $attachment_id <= 0 ) {
+	        WP_CLI::error( 'Invalid attachment ID.' );
+	    }
+	
+	    $url = wp_get_attachment_url( $attachment_id );
+	
+	    if ( empty( $url ) ) {
+	        WP_CLI::error( 'Failed to retrieve attachment URL for ID: ' . $attachment_id );
+	    }
+	
+	    // By switching the URLs from http:// to https:// we save a request, since it will be redirected to the SSL url
+	    if ( is_ssl() ) {
+	        $url = str_replace( 'http://', 'https://', $url );
+	    }
+	
+	    $ch = curl_init();
+	    curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
+	    curl_setopt( $ch, CURLOPT_URL, $url );
+	    curl_setopt( $ch, CURLOPT_FOLLOWLOCATION, true );
+	    curl_setopt( $ch, CURLOPT_NOBODY, true );
+	
+	    // Check for errors before setting options
+	    if (curl_errno($ch)) {
+	        WP_CLI::error( 'cURL error for Attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
+	    }
+	
+	    $response = curl_exec( $ch );
+	    
+	    // Check for errors after executing cURL request
+	    if (curl_errno($ch)) {
+	        WP_CLI::error( 'cURL error for Attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
+	    }
+	
+	    $response_code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+	    curl_close( $ch );
+	
+	    if ( 200 === $response_code ) {
+	        // Process the response and upload the attachment to S3
+	        // ...
+	        WP_CLI::success( 'Attachment ID ' . $attachment_id . ' successfully uploaded to S3.' );
+	    } else {
+	        WP_CLI::error( 'Failed to fetch attachment from URL for Attachment ID ' . $attachment_id . ': ' . $url );
+	    }
+	}
+	
+	/**
 	 * Upload all validated media to S3
 	 *
 	 * @subcommand upload-all

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -22,7 +22,7 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 	
 		$url = wp_get_attachment_url( $attachment_id );
 	
-		if ( empty( $url ) ) {
+		if ( false === $url || '' === $url ) {
 			WP_CLI::error( 'Failed to retrieve attachment URL for ID: ' . $attachment_id );
 		}
 	

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -19,7 +19,7 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 		$url = wp_get_attachment_url( $attachment_id );
 	
 		if ( empty( $url ) ) {
-		    WP_CLI::error( 'Failed to retrieve attachment URL for ID: ' . $attachment_id );
+			WP_CLI::error( 'Failed to retrieve attachment URL for ID: ' . $attachment_id );
 		}
 	
 		// By switching the URLs from http:// to https:// we save a request, since it will be redirected to the SSL url

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -4,7 +4,7 @@ use \WP_CLI\Utils;
 
 class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 
-    	/**
+	/**
 	* Upload a single attachment to S3
 	*
 	* @synopsis <attachment_id>

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -14,7 +14,7 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
                 $from    = wp_get_upload_dir();
                 $to      = S3_Media_Sync::init()->get_s3_bucket_url();
 		
-		$attachment_id = intval( $args[0] );
+		$attachment_id = absint( $args[0] );
 	
 		if ( $attachment_id <= 0 ) {
 			WP_CLI::error( 'Invalid attachment ID.' );

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -39,7 +39,7 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 	
 		// Check for errors before setting options
 		if (curl_errno($ch)) {
-			WP_CLI::error( 'cURL error for Attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
+			WP_CLI::error( 'cURL error for attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
 		}
 	
 		$response = curl_exec( $ch );

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -11,8 +11,8 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 	*/
 	public function upload( $args, $assoc_args ) {
 		// Get the source and destination and initialize some concurrency variables
-                $from    = wp_get_upload_dir();
-                $to      = S3_Media_Sync::init()->get_s3_bucket_url();
+		$from	= wp_get_upload_dir();
+		$to	= S3_Media_Sync::init()->get_s3_bucket_url();
 		
 		$attachment_id = absint( $args[0] );
 	

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -46,7 +46,7 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 		
 		// Check for errors after executing cURL request
 		if (curl_errno($ch)) {
-			WP_CLI::error( 'cURL error for Attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
+			WP_CLI::error( 'cURL error for attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
 		}
 	
 		$response_code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -16,7 +16,7 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 		
 		$attachment_id = absint( $args[0] );
 	
-		if ( $attachment_id <= 0 ) {
+		if ( $attachment_id === 0 ) {
 			WP_CLI::error( 'Invalid attachment ID.' );
 		}
 	

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -62,7 +62,7 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 			}
 			WP_CLI::success( 'Attachment ID ' . $attachment_id . ' successfully uploaded to S3.' );
 		} else {
-			WP_CLI::error( 'Failed to fetch attachment from URL for Attachment ID ' . $attachment_id . ': ' . $url );
+			WP_CLI::error( 'Failed to fetch attachment from URL for attachment ID ' . $attachment_id . ': ' . $url );
 		}
 	}
 	

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -45,7 +45,7 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 		$response = curl_exec( $ch );
 		
 		// Check for errors after executing cURL request
-		if (curl_errno($ch)) {
+		if ( curl_errno( $ch ) ) {
 			WP_CLI::error( 'cURL error for attachment ID ' . $attachment_id . ': ' . curl_error( $ch ) );
 		}
 	


### PR DESCRIPTION
This PR will address https://github.com/Automattic/s3-media-sync/issues/19 whereby we introduce a new command to upload a single post_type attachment based on its ID.

Example use case

```
wp s3-media upload 12345
```

The benefit of this command is that, based on a known lists of attachment IDs we need to upload, we could combine it with xargs like

```
xargs -n 1 -P 5 -a attachment_ids.txt wp s3-media upload
```

to granularly upload them to the S3 bucket, and so avoiding the necessity of a full sync using `upload-all`.