### PR TITLE
fix: Add undefined property

### DIFF
--- a/inc/class-s3-media-sync.php
+++ b/inc/class-s3-media-sync.php
@@ -4,6 +4,7 @@ class S3_Media_Sync {
 
 	private static $instance;
 	private $settings;
+	private $s3;
 
 	/**
 	 *


### PR DESCRIPTION
Creation of dynamic property is deprecated for PHP 8.2 and later.