### PR TITLE
Separate settings handling into dedicated class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,14 @@
 		"yoast/wp-test-utils": "^1.2",
 		"mockery/mockery": "^1.6"
 	},
+	"autoload": {
+		"classmap": [
+			"inc/"
+		],
+		"exclude-from-classmap": [
+			"inc/class-s3-media-sync-wp-cli.php"
+		]
+	},
 	"autoload-dev": {
 		"psr-4": {
 			"S3_Media_Sync\\Tests\\": "tests/"

--- a/inc/class-s3-media-sync-settings.php
+++ b/inc/class-s3-media-sync-settings.php
@@ -1,0 +1,254 @@
+<?php
+
+class S3_Media_Sync_Settings {
+	/**
+	 * Plugin settings
+	 *
+	 * @var array
+	 */
+	protected $settings;
+
+	public function __construct() {
+		$this->settings = get_option( 's3_media_sync_settings', [] );
+	}
+
+	/**
+	 * Initialize settings functionality
+	 */
+	public function init() {
+		add_action( 'admin_menu', [ $this, 'register_menu_settings' ] );
+		add_action( 'admin_init', [ $this, 'settings_screen_init' ] );
+	}
+
+	/**
+	 * Register the submenu for updating the settings
+	 */
+	public function register_menu_settings() {
+		add_submenu_page(
+			'options-general.php',
+			__( 'S3 Media Sync', 's3-media-sync' ),
+			__( 'S3 Media Sync', 's3-media-sync' ),
+			'manage_options',
+			's3_media_sync',
+			[ $this, 'render_settings_page' ]
+		);
+	}
+
+	/**
+	 * Validate the settings page keys
+	 */
+	public function settings_validation( $input ) {
+		// Only proceed to validate the bucket if all necessary settings are set
+		if ( ! $this->has_required_settings() ) {
+			return $input;
+		}
+
+		// This check will test the API keys provided
+		$s3_client = new S3_Media_Sync();
+		if ( false === $s3_client->s3()->doesBucketExist( $this->settings['bucket'] ) ) {
+			add_settings_error(
+				's3_media_sync_settings',
+				's3-media-sync-settings-error',
+				__( 'The credentials provided are incorrect. The AWS bucket cannot be found.', 's3-media-sync' )
+			);
+		}
+
+		return $input;
+	}
+
+	/**
+	 * Render the settings page
+	 */
+	public function render_settings_page() {
+		?>
+		<div class="wrap">
+			<h2>S3 Media Sync</h2>
+				<form action='options.php' method='post'>
+					<?php settings_fields( 's3_media_sync_settings_page' ); ?>
+					<?php do_settings_sections( 's3_media_sync_settings_page' ); ?>
+					<?php submit_button(); ?>
+				</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Initialize the settings screen
+	 */
+	public function settings_screen_init() {
+		// Register the settings page
+		register_setting( 
+			's3_media_sync_settings_page', 
+			's3_media_sync_settings', 
+			[ $this, 'settings_validation' ]
+		);
+
+		// Add the settings fields
+		add_settings_section(
+			's3_media_sync_settings',
+			__( 'Settings', 's3-media-sync' ),
+			null,
+			's3_media_sync_settings_page'
+		);
+
+		// Setting: S3 Access Key ID
+		add_settings_field(
+			'key',
+			__( 'S3 Access Key ID', 's3-media-sync' ),
+			[ $this, 's3_key_render' ],
+			's3_media_sync_settings_page',
+			's3_media_sync_settings',
+			[ 'label_for' => 's3_media_sync_settings[key]' ]
+		);
+
+		// Setting: S3 Secret Access Key
+		add_settings_field(
+			'secret',
+			__( 'S3 Secret Access Key', 's3-media-sync' ),
+			[ $this, 's3_secret_render' ],
+			's3_media_sync_settings_page',
+			's3_media_sync_settings',
+			[ 'label_for' => 's3_media_sync_settings[secret]' ]
+		);
+
+		// Setting: S3 Bucket Name
+		add_settings_field(
+			'bucket',
+			__( 'S3 Bucket Name', 's3-media-sync' ),
+			[ $this, 's3_bucket_render' ],
+			's3_media_sync_settings_page',
+			's3_media_sync_settings',
+			[ 'label_for' => 's3_media_sync_settings[bucket]' ]
+		);
+
+		// Setting: S3 Region
+		add_settings_field(
+			'region',
+			__( 'S3 Region', 's3-media-sync' ),
+			[ $this, 's3_region_render' ],
+			's3_media_sync_settings_page',
+			's3_media_sync_settings',
+			[ 'label_for' => 's3_media_sync_settings[region]' ]
+		);
+
+		// Setting: S3 Object ACL
+		add_settings_field(
+			'object_acl',
+			__( 'S3 Object ACL', 's3-media-sync' ),
+			[ $this, 's3_object_acl_render' ],
+			's3_media_sync_settings_page',
+			's3_media_sync_settings',
+			[ 'label_for' => 's3_media_sync_settings[object_acl]' ]
+		);
+	}
+
+	// Render the S3 Access Key ID text field
+	public function s3_key_render() {
+		$options = get_option( 's3_media_sync_settings' );
+		$value   = ! empty( $options['key'] ) ? $options['key'] : '';
+		printf(
+			'<input type="text" name="s3_media_sync_settings[key]" id="s3_media_sync_settings[key]" value="%s">',
+			esc_attr( $value )
+		);
+	}
+
+	// Render the S3 Secret Access Key text field
+	public function s3_secret_render() {
+		$options = get_option( 's3_media_sync_settings' );
+		$value   = ! empty( $options['secret'] ) ? $options['secret'] : '';
+		printf(
+			'<input type="text" name="s3_media_sync_settings[secret]" id="s3_media_sync_settings[secret]" value="%s">',
+			esc_attr( $value )
+		);
+	}
+
+	// Render the S3 Bucket Name text field
+	public function s3_bucket_render() {
+		$options = get_option( 's3_media_sync_settings' );
+		$value   = ! empty( $options['bucket'] ) ? $options['bucket'] : '';
+		printf(
+			'<input type="text" name="s3_media_sync_settings[bucket]" id="s3_media_sync_settings[bucket]" value="%s">',
+			esc_attr( $value )
+		);
+	}
+
+	// Render the S3 Region text field
+	public function s3_region_render() {
+		$options = get_option( 's3_media_sync_settings' );
+		$value   = ! empty( $options['region'] ) ? $options['region'] : '';
+		printf(
+			'<input type="text" name="s3_media_sync_settings[region]" id="s3_media_sync_settings[region]" value="%s">',
+			esc_attr( $value )
+		);
+	}
+
+	// Render the S3 Object ACL dropdown
+	public function s3_object_acl_render() {
+		$options = get_option('s3_media_sync_settings');
+		$value = !empty($options['object_acl']) ? $options['object_acl'] : '';
+		?>
+		<select name="s3_media_sync_settings[object_acl]" id="s3_media_sync_settings[object_acl]">
+			<option<?php selected($value, 'private', true); ?>><?php _e('private', 's3-media-sync'); ?></option>
+			<option<?php selected($value, 'public-read', true); ?>><?php _e('public-read', 's3-media-sync'); ?></option>
+		</select>
+		<?php
+	}
+
+	/**
+	 * Check if all required s3 bucket settings are set.
+	 *
+	 * @return bool
+	 */
+	public function has_required_settings() {
+		$required_keys = [ 'bucket', 'key', 'secret', 'region' ];
+
+		foreach ( $required_keys as $key ) {
+			if ( empty( $this->settings[ $key ] ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get all settings
+	 *
+	 * @return array
+	 */
+	public function get_settings() {
+		return $this->settings;
+	}
+
+	/**
+	 * Update settings
+	 *
+	 * @param array $settings New settings to save
+	 */
+	public function update_settings( array $settings ) {
+		$this->settings = $settings;
+		update_option( 's3_media_sync_settings', $settings );
+	}
+
+	/**
+	 * Get a specific setting value
+	 *
+	 * @param string $key Setting key to retrieve
+	 * @param mixed $default Default value if setting doesn't exist
+	 * @return mixed
+	 */
+	public function get_setting( string $key, $default = null ) {
+		return $this->settings[$key] ?? $default;
+	}
+
+	/**
+	 * Update a specific setting
+	 *
+	 * @param string $key Setting key to update
+	 * @param mixed $value New value
+	 */
+	public function update_setting( string $key, $value ) {
+		$this->settings[$key] = $value;
+		update_option( 's3_media_sync_settings', $this->settings );
+	}
+} 

--- a/inc/class-s3-media-sync-settings.php
+++ b/inc/class-s3-media-sync-settings.php
@@ -44,7 +44,7 @@ class S3_Media_Sync_Settings {
 		}
 
 		// This check will test the API keys provided
-		$s3_client = new S3_Media_Sync();
+		$s3_client = new S3_Media_Sync( $this );
 		if ( false === $s3_client->s3()->doesBucketExist( $this->settings['bucket'] ) ) {
 			add_settings_error(
 				's3_media_sync_settings',
@@ -62,7 +62,7 @@ class S3_Media_Sync_Settings {
 	public function render_settings_page() {
 		?>
 		<div class="wrap">
-			<h2>S3 Media Sync</h2>
+			<h2><?php _e( 'S3 Media Sync', 's3-media-sync' ); ?></h2>
 				<form action='options.php' method='post'>
 					<?php settings_fields( 's3_media_sync_settings_page' ); ?>
 					<?php do_settings_sections( 's3_media_sync_settings_page' ); ?>

--- a/inc/class-s3-media-sync.php
+++ b/inc/class-s3-media-sync.php
@@ -1,27 +1,13 @@
 <?php
 
 class S3_Media_Sync {
-
-	private static $instance;
 	private $settings;
 	private $s3;
 	private $settings_handler;
 
-	/**
-	 *
-	 * @return S3_Media_Sync
-	 */
-	public static function init() {
-		if ( ! self::$instance ) {
-			self::$instance = new S3_Media_Sync();
-		}
-
-		return self::$instance;
-	}
-
-	public function __construct() {
-		$this->settings_handler = new S3_Media_Sync_Settings();
-		$this->settings = $this->settings_handler->get_settings();
+	public function __construct( S3_Media_Sync_Settings $settings_handler ) {
+		$this->settings_handler = $settings_handler;
+		$this->settings         = $this->settings_handler->get_settings();
 	}
 
 	/**

--- a/inc/class-s3-media-sync.php
+++ b/inc/class-s3-media-sync.php
@@ -5,6 +5,7 @@ class S3_Media_Sync {
 	private static $instance;
 	private $settings;
 	private $s3;
+	private $settings_handler;
 
 	/**
 	 *
@@ -19,7 +20,17 @@ class S3_Media_Sync {
 	}
 
 	public function __construct() {
-		$this->settings = get_option( 's3_media_sync_settings' );
+		$this->settings_handler = new S3_Media_Sync_Settings();
+		$this->settings = $this->settings_handler->get_settings();
+	}
+
+	/**
+	 * Get the settings handler instance
+	 *
+	 * @return S3_Media_Sync_Settings
+	 */
+	public function get_settings_handler() {
+		return $this->settings_handler;
 	}
 
 	public function get_s3_bucket() {
@@ -37,14 +48,14 @@ class S3_Media_Sync {
 		// Load the plugin text domain for translation
 		load_plugin_textdomain( 's3-media-sync', false, basename( dirname( __FILE__ ) ) . '/languages/' );
 
-		// Register and configure the stream wrapper
-		$this->register_stream_wrapper();
+		// Initialize settings
+		$this->settings_handler->init();
 
-		// Register and render the settings screen
-		add_action( 'admin_menu', [ $this, 'register_menu_settings' ] );
-		add_action( 'admin_init', [ $this, 'settings_screeen_init' ] );
+		// Only proceed with stream wrapper and hooks if we have all required settings
+		if ( $this->settings_handler->has_required_settings() && isset($this->settings['region']) && !empty($this->settings['region']) ) {
+			// Register and configure the stream wrapper
+			$this->register_stream_wrapper();
 
-		if ( $this->has_required_settings() ) {
 			// Perform on-the-fly media syncs by hooking into these actions
 			add_filter( 'wp_handle_upload', [ $this, 'add_attachment_to_s3' ], 10, 2 );
 			add_action( 'delete_attachment', [ $this, 'delete_attachment_from_s3' ], 10, 1 );
@@ -139,7 +150,12 @@ class S3_Media_Sync {
 	 */
 	public function register_stream_wrapper() {
 		// Only proceed to register the stream wrapper if all required fields are set
-		if ( ! $this->has_required_settings() ) {
+		if ( ! $this->settings_handler->has_required_settings() ) {
+			return;
+		}
+
+		// Ensure we have all required settings for S3 client
+		if ( ! isset($this->settings['region']) || empty($this->settings['region']) ) {
 			return;
 		}
 
@@ -148,172 +164,6 @@ class S3_Media_Sync {
 		$objectAcl = isset( $this->settings['object_acl'] ) ? sanitize_text_field( $this->settings['object_acl'] ) : 'public-read';
 		stream_context_set_option( stream_context_get_default(), 's3', 'ACL', $objectAcl );
 		stream_context_set_option( stream_context_get_default(), 's3', 'seekable', true );
-	}
-
-	/**
-	 * Register the submenu for updating the settings
-	 */
-	public function register_menu_settings() {
-		add_submenu_page(
-			'options-general.php',
-			__( 'S3 Media Sync', 's3-media-sync' ),
-			__( 'S3 Media Sync', 's3-media-sync' ),
-			'manage_options',
-			's3_media_sync',
-			[ $this, 'render_settings_page' ]
-		);
-	}
-
-	/**
-	 * Validate the settings page keys
-	 */
-	function s3_media_sync_settings_validation( $input ) {
-		// Only proceed to validate the bucket if all necessary settings are set
-		if ( ! $this->has_required_settings() ) {
-			return $input;
-		}
-
-		// This check will test the API keys provided
-		if ( false === $this->s3()->doesBucketExist( $this->settings['bucket'] ) ) {
-			add_settings_error(
-				's3_media_sync_settings',
-				's3-media-sync-settings-error',
-				__( 'The credentials provided are incorrect. The AWS bucket cannot be found.', 's3-media-sync' )
-			);
-		}
-
-		return $input;
-	}
-
-	/**
-	 * Render the settings page
-	 */
-	public function render_settings_page() {
-		?>
-		<div class="wrap">
-			<h2>S3 Media Sync</h2>
-				<form action='options.php' method='post'>
-					<?php settings_fields( 's3_media_sync_settings_page' ); ?>
-					<?php do_settings_sections( 's3_media_sync_settings_page' ); ?>
-					<?php submit_button(); ?>
-				</form>
-		</div>
-		<?php
-	}
-
-	public function settings_screeen_init() {
-		// Register the settings page
-		register_setting( 's3_media_sync_settings_page', 's3_media_sync_settings', [ $this, 's3_media_sync_settings_validation' ] );
-
-		// Add the settings fields
-		add_settings_section(
-			's3_media_sync_settings',
-			__( 'Settings', 's3-media-sync' ),
-			null,
-			's3_media_sync_settings_page'
-		);
-
-		// Setting: S3 Access Key ID
-		add_settings_field(
-			'key',
-			__( 'S3 Access Key ID', 's3-media-sync' ),
-			[ $this, 's3_key_render' ],
-			's3_media_sync_settings_page',
-			's3_media_sync_settings',
-			[ 'label_for' => 's3_media_sync_settings[key]' ]
-		);
-
-		// Setting: S3 Secret Access Key
-		add_settings_field(
-			'secret',
-			__( 'S3 Secret Access Key', 's3-media-sync' ),
-			[ $this, 's3_secret_render' ],
-			's3_media_sync_settings_page',
-			's3_media_sync_settings',
-			[ 'label_for' => 's3_media_sync_settings[secret]' ]
-		);
-
-		// Setting: S3 Bucket Name
-		add_settings_field(
-			'bucket',
-			__( 'S3 Bucket Name', 's3-media-sync' ),
-			[ $this, 's3_bucket_render' ],
-			's3_media_sync_settings_page',
-			's3_media_sync_settings',
-			[ 'label_for' => 's3_media_sync_settings[bucket]' ]
-		);
-
-		// Setting: S3 Region
-		add_settings_field(
-			'region',
-			__( 'S3 Region', 's3-media-sync' ),
-			[ $this, 's3_region_render' ],
-			's3_media_sync_settings_page',
-			's3_media_sync_settings',
-			[ 'label_for' => 's3_media_sync_settings[region]' ]
-		);
-
-		// Setting: S3 Object ACL
-		add_settings_field(
-			'object_acl',
-			__( 'S3 Object ACL', 's3-media-sync' ),
-			[ $this, 's3_object_acl_render' ],
-			's3_media_sync_settings_page',
-			's3_media_sync_settings',
-			[ 'label_for' => 's3_media_sync_settings[object_acl]' ]
-		);
-	}
-
-	// Render the S3 Access Key ID text field
-	public function s3_key_render() {
-		$options = get_option( 's3_media_sync_settings' );
-		$value   = ! empty( $options['key'] ) ? $options['key'] : '';
-		printf(
-			'<input type="text" name="s3_media_sync_settings[key]" id="s3_media_sync_settings[key]" value="%s">',
-			esc_attr( $value )
-		);
-	}
-
-	// Render the S3 Secret Access Key text field
-	public function s3_secret_render() {
-		$options = get_option( 's3_media_sync_settings' );
-		$value   = ! empty( $options['secret'] ) ? $options['secret'] : '';
-		printf(
-			'<input type="text" name="s3_media_sync_settings[secret]" id="s3_media_sync_settings[secret]" value="%s">',
-			esc_attr( $value )
-		);
-	}
-
-	// Render the S3 Bucket Name text field
-	public function s3_bucket_render() {
-		$options = get_option( 's3_media_sync_settings' );
-		$value   = ! empty( $options['bucket'] ) ? $options['bucket'] : '';
-		printf(
-			'<input type="text" name="s3_media_sync_settings[bucket]" id="s3_media_sync_settings[bucket]" value="%s">',
-			esc_attr( $value )
-		);
-	}
-
-	// Render the S3 Region text field
-	public function s3_region_render() {
-		$options = get_option( 's3_media_sync_settings' );
-		$value   = ! empty( $options['region'] ) ? $options['region'] : '';
-		printf(
-			'<input type="text" name="s3_media_sync_settings[region]" id="s3_media_sync_settings[region]" value="%s">',
-			esc_attr( $value )
-		);
-	}
-
-	// Render the S3 Object ACL dropdown
-	public function s3_object_acl_render() {
-		$options = get_option('s3_media_sync_settings');
-		$value = !empty($options['object_acl']) ? $options['object_acl'] : '';
-		?>
-		<select name="s3_media_sync_settings[object_acl]" id="s3_media_sync_settings[object_acl]">
-			<option<?php selected($value, 'private', true); ?>><?php _e('private', 's3-media-sync'); ?></option>
-			<option<?php selected($value, 'public-read', true); ?>><?php _e('public-read', 's3-media-sync'); ?></option>
-		</select>
-		<?php
 	}
 
 	/**
@@ -328,12 +178,12 @@ class S3_Media_Sync {
 
 		$params = array( 'version' => 'latest' );
 
-		if ( $this->settings['key'] && $this->settings['secret'] ) {
+		if ( isset($this->settings['key']) && isset($this->settings['secret']) && $this->settings['key'] && $this->settings['secret'] ) {
 			$params['credentials']['key']    = $this->settings['key'];
 			$params['credentials']['secret'] = $this->settings['secret'];
 		}
 
-		if ( $this->settings['region'] ) {
+		if ( isset($this->settings['region']) && $this->settings['region'] ) {
 			$params['signature'] = 'v4';
 			$params['region']    = $this->settings['region'];
 		}
@@ -352,22 +202,5 @@ class S3_Media_Sync {
 		$this->s3 = Aws\S3\S3Client::factory( $params );
 
 		return $this->s3;
-	}
-
-	/**
-	 * Check if all required s3 bucket settings are set.
-	 *
-	 * @return bool
-	 */
-	private function has_required_settings() {
-		$required_keys = [ 'bucket', 'key', 'secret', 'region' ];
-
-		foreach ( $required_keys as $key ) {
-			if ( empty( $this->settings[ $key ] ) ) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 }

--- a/s3-media-sync.php
+++ b/s3-media-sync.php
@@ -9,24 +9,22 @@
  * Version: 1.4.1
  */
 
-// Define plugin constants
 define( 'S3_MEDIA_SYNC_FILE', __FILE__ );
 
-// Load required files
 require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-settings.php';
 require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync.php';
+require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-stream-wrapper.php';
 
-/**
- * Class that handles s3 stream wrapper
- */
-require_once plugin_dir_path( __FILE__ ) . 'inc/class-s3-media-sync-stream-wrapper.php';
-
-/**
- * Class that adds WP-CLI commands
- */
-if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WPCOM_VIP_CLI_Command' ) ) {
+if ( defined( 'WP_CLI' ) && class_exists( 'WPCOM_VIP_CLI_Command' ) ) {
 	require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-wp-cli.php';
 }
 
-// Initialize the plugin
-add_action( 'plugins_loaded', [ S3_Media_Sync::init(), 'setup' ] );
+// Initialize the plugin with dependencies
+add_action(
+	'plugins_loaded',
+	function() {
+		$settings_handler = new S3_Media_Sync_Settings();
+		$s3_media_sync = new S3_Media_Sync( $settings_handler );
+		$s3_media_sync->setup();
+	}
+);

--- a/s3-media-sync.php
+++ b/s3-media-sync.php
@@ -9,17 +9,17 @@
  * Version: 1.4.1
  */
 
- const S3_MEDIA_SYNC_FILE = __FILE__;
+// Define plugin constants
+define( 'S3_MEDIA_SYNC_FILE', __FILE__ );
+
+// Load required files
+require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-settings.php';
+require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync.php';
 
 /**
  * Class that handles s3 stream wrapper
  */
 require_once plugin_dir_path( __FILE__ ) . 'inc/class-s3-media-sync-stream-wrapper.php';
-
-/**
- * Class that handles core plugin functionality
- */
-require_once plugin_dir_path( __FILE__ ) . 'inc/class-s3-media-sync.php';
 
 /**
  * Class that adds WP-CLI commands
@@ -28,18 +28,5 @@ if ( defined( 'WP_CLI' ) && WP_CLI && class_exists( 'WPCOM_VIP_CLI_Command' ) ) 
 	require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-wp-cli.php';
 }
 
-/**
- * Set up the plugin
- */
-function s3_media_sync_setup() {
-
-	// Ensure the AWS SDK can be loaded.
-	if ( ! class_exists( '\\Aws\\S3\\S3Client' ) ) {
-		// Require AWS Autoloader file.
-		require_once dirname( __FILE__ ) . '/vendor/autoload.php';
-	}
-
-	$instance = S3_Media_Sync::init();
-	$instance->setup();
-}
-add_action( 'plugins_loaded', 's3_media_sync_setup' );
+// Initialize the plugin
+add_action( 'plugins_loaded', [ S3_Media_Sync::init(), 'setup' ] );

--- a/s3-media-sync.php
+++ b/s3-media-sync.php
@@ -11,9 +11,9 @@
 
 define( 'S3_MEDIA_SYNC_FILE', __FILE__ );
 
-require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-settings.php';
-require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync.php';
-require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-stream-wrapper.php';
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
 
 if ( defined( 'WP_CLI' ) && class_exists( 'WPCOM_VIP_CLI_Command' ) ) {
 	require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-wp-cli.php';

--- a/tests/Integration/BulkOperationsTest.php
+++ b/tests/Integration/BulkOperationsTest.php
@@ -16,8 +16,9 @@ use S3_Media_Sync\Tests\TestCase;
  *
  * @group integration
  * @group bulk-operations
- * @covers S3_Media_Sync
- * @uses S3_Media_Sync_Stream_Wrapper
+ * @covers \S3_Media_Sync
+ * @uses \S3_Media_Sync_Stream_Wrapper
+ * @uses \S3_Media_Sync_Settings
  */
 class BulkOperationsTest extends TestCase {
 

--- a/tests/Integration/ErrorHandlingTest.php
+++ b/tests/Integration/ErrorHandlingTest.php
@@ -10,6 +10,7 @@ namespace S3_Media_Sync\Tests\Integration;
 use Mockery;
 use PHPUnit\Framework\Assert;
 use S3_Media_Sync;
+use S3_Media_Sync_Settings;
 use S3_Media_Sync\Tests\TestCase;
 
 /**
@@ -30,13 +31,9 @@ class ErrorHandlingTest extends TestCase {
 	public function set_up(): void {
 		parent::set_up();
 		
-		$this->s3_media_sync = new S3_Media_Sync();
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings',
-			$this->default_settings
-		);
+		$this->settings_handler = new S3_Media_Sync_Settings();
+		$this->settings_handler->update_settings($this->default_settings);
+		$this->s3_media_sync = new S3_Media_Sync($this->settings_handler);
 		
 		$this->test_file = $this->create_temp_file();
 	}

--- a/tests/Integration/ErrorHandlingTest.php
+++ b/tests/Integration/ErrorHandlingTest.php
@@ -17,8 +17,9 @@ use S3_Media_Sync\Tests\TestCase;
  *
  * @group integration
  * @group error-handling
- * @covers S3_Media_Sync
- * @uses S3_Media_Sync_Stream_Wrapper
+ * @covers \S3_Media_Sync
+ * @uses \S3_Media_Sync_Stream_Wrapper
+ * @uses \S3_Media_Sync_Settings
  */
 class ErrorHandlingTest extends TestCase {
 

--- a/tests/Integration/FileDeleteTest.php
+++ b/tests/Integration/FileDeleteTest.php
@@ -16,8 +16,9 @@ use S3_Media_Sync\Tests\TestCase;
  *
  * @group integration
  * @group file-delete
- * @covers S3_Media_Sync
- * @uses S3_Media_Sync_Stream_Wrapper
+ * @covers \S3_Media_Sync
+ * @uses \S3_Media_Sync_Stream_Wrapper
+ * @uses \S3_Media_Sync_Settings
  */
 class FileDeleteTest extends TestCase {
 

--- a/tests/Integration/HooksTest.php
+++ b/tests/Integration/HooksTest.php
@@ -81,7 +81,6 @@ class HooksTest extends TestCase {
 	 * 
 	 * @param array $settings            The settings to test with.
 	 * @param bool  $should_be_registered Whether the hooks should be registered.
-	 * @throws \ReflectionException If reflection fails.
 	 */
 	public function test_media_syncs_hooks_registration( array $settings, bool $should_be_registered ): void {
 		$this::set_private_property(

--- a/tests/Integration/HooksTest.php
+++ b/tests/Integration/HooksTest.php
@@ -15,8 +15,9 @@ use S3_Media_Sync\Tests\TestCase;
  *
  * @group integration
  * @group hooks
- * @covers S3_Media_Sync
- * @uses S3_Media_Sync_Stream_Wrapper
+ * @covers \S3_Media_Sync
+ * @uses \S3_Media_Sync_Stream_Wrapper
+ * @uses \S3_Media_Sync_Settings
  */
 class HooksTest extends TestCase {
 

--- a/tests/Integration/ImageEditorTest.php
+++ b/tests/Integration/ImageEditorTest.php
@@ -17,8 +17,9 @@ use WP_Image_Editor;
  *
  * @group integration
  * @group image-editor
- * @covers S3_Media_Sync
- * @uses S3_Media_Sync_Stream_Wrapper
+ * @covers \S3_Media_Sync
+ * @uses \S3_Media_Sync_Stream_Wrapper
+ * @uses \S3_Media_Sync_Settings
  */
 class ImageEditorTest extends TestCase {
 

--- a/tests/Integration/MediaUploadTest.php
+++ b/tests/Integration/MediaUploadTest.php
@@ -16,8 +16,9 @@ use S3_Media_Sync\Tests\TestCase;
  *
  * @group integration
  * @group media-upload
- * @covers S3_Media_Sync
- * @uses S3_Media_Sync_Stream_Wrapper
+ * @covers \S3_Media_Sync
+ * @uses \S3_Media_Sync_Stream_Wrapper
+ * @uses \S3_Media_Sync_Settings
  */
 class MediaUploadTest extends TestCase {
 

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -17,8 +17,9 @@ use S3_Media_Sync\Tests\TestCase;
  *
  * @group integration
  * @group settings
- * @covers S3_Media_Sync
- * @uses S3_Media_Sync_Stream_Wrapper
+ * @covers \S3_Media_Sync_Settings
+ * @uses \S3_Media_Sync
+ * @uses \S3_Media_Sync_Stream_Wrapper
  */
 class SettingsTest extends TestCase {
 
@@ -87,15 +88,9 @@ class SettingsTest extends TestCase {
 			->with( $settings['bucket'] )
 			->andReturn( false );
 
-		// Update WordPress option
+		// Update WordPress option and settings handler
 		update_option( 's3_media_sync_settings', $settings );
-
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings',
-			$settings
-		);
+		$this->settings_handler->update_settings( $settings );
 
 		// Only set the S3 client if we should validate
 		if ( $should_validate ) {
@@ -112,7 +107,7 @@ class SettingsTest extends TestCase {
 		// Clear any errors that might have been set during setup
 		$wp_settings_errors = [];
 
-		$this->s3_media_sync->s3_media_sync_settings_validation( $settings );
+		$this->settings_handler->settings_validation( $settings );
 
 		$admin_error_codes = wp_list_pluck( get_settings_errors(), 'code' );
 
@@ -137,20 +132,12 @@ class SettingsTest extends TestCase {
 	 * @throws \ReflectionException If reflection fails.
 	 */
 	public function test_settings_are_saved( array $settings, string $error_code, bool $should_validate ): void {
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings',
-			$settings
-		);
+		// Update settings
+		$this->settings_handler->update_settings( $settings );
 
 		$this->s3_media_sync->setup();
 
-		$saved_settings = $this::get_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings'
-		);
+		$saved_settings = $this->settings_handler->get_settings();
 
 		Assert::assertSame( $settings, $saved_settings );
 	}

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -11,9 +11,11 @@ use Aws\S3\S3Client;
 use Mockery;
 use PHPUnit\Framework\Assert;
 use S3_Media_Sync\Tests\TestCase;
+use S3_Media_Sync;
+use S3_Media_Sync_Settings;
 
 /**
- * Test case for S3 Media Sync settings validation.
+ * Test case for S3 Media Sync settings functionality.
  *
  * @group integration
  * @group settings
@@ -75,7 +77,6 @@ class SettingsTest extends TestCase {
 	 * @param array  $settings    The settings to test with.
 	 * @param string $error_code  The expected error code.
 	 * @param bool   $should_validate Whether validation should be performed.
-	 * @throws \ReflectionException If reflection fails.
 	 */
 	public function test_invalid_settings_cause_admin_error_notice( array $settings, string $error_code, bool $should_validate ): void {
 		// Clear any existing errors
@@ -129,7 +130,6 @@ class SettingsTest extends TestCase {
 	 * @param array  $settings    The settings to test with.
 	 * @param string $error_code  The expected error code.
 	 * @param bool   $should_validate Whether validation should be performed.
-	 * @throws \ReflectionException If reflection fails.
 	 */
 	public function test_settings_are_saved( array $settings, string $error_code, bool $should_validate ): void {
 		// Update settings

--- a/tests/Integration/StreamWrapperTest.php
+++ b/tests/Integration/StreamWrapperTest.php
@@ -52,7 +52,6 @@ class StreamWrapperTest extends TestCase {
 	 * @dataProvider data_provider_stream_wrapper_settings
 	 * 
 	 * @param array $settings The settings to test with.
-	 * @throws \ReflectionException If reflection fails.
 	 */
 	public function test_stream_wrapper_registered( array $settings ): void {
 		$this::set_private_property(
@@ -73,7 +72,6 @@ class StreamWrapperTest extends TestCase {
 	 * @dataProvider data_provider_stream_wrapper_settings
 	 * 
 	 * @param array $settings The settings to test with.
-	 * @throws \ReflectionException If reflection fails.
 	 */
 	public function test_stream_wrapper_functionality( array $settings ): void {
 		// Set up the plugin with mock client.

--- a/tests/Integration/StreamWrapperTest.php
+++ b/tests/Integration/StreamWrapperTest.php
@@ -21,8 +21,9 @@ use S3_Media_Sync\Tests\TestCase;
  *
  * @group integration
  * @group stream-wrapper
- * @covers S3_Media_Sync
- * @covers S3_Media_Sync_Stream_Wrapper
+ * @covers \S3_Media_Sync_Stream_Wrapper
+ * @uses \S3_Media_Sync
+ * @uses \S3_Media_Sync_Settings
  */
 class StreamWrapperTest extends TestCase {
 

--- a/tests/Integration/UserInterfaceTest.php
+++ b/tests/Integration/UserInterfaceTest.php
@@ -9,18 +9,26 @@ use S3_Media_Sync\Tests\TestCase;
  *
  * @package S3_Media_Sync
  * @group integration
- * @covers S3_Media_Sync
+ * @covers \S3_Media_Sync_Settings
+ * @uses \S3_Media_Sync
  */
 class UserInterfaceTest extends TestCase {
 
+    protected $settings_handler;
+
+    public function set_up(): void {
+        parent::set_up();
+        $this->settings_handler = new \S3_Media_Sync_Settings();
+    }
+
     public function test_s3_key_render_displays_correct_html() {
-        // Simulate the options array and update WordPress option
+        // Simulate the options array and update settings
         $options = ['key' => 'test-key'];
-        update_option('s3_media_sync_settings', $options);
+        $this->settings_handler->update_settings($options);
 
         // Start output buffering
         ob_start();
-        $this->s3_media_sync->s3_key_render();
+        $this->settings_handler->s3_key_render();
         $output = ob_get_clean();
 
         // Assert the output contains the expected HTML
@@ -28,13 +36,13 @@ class UserInterfaceTest extends TestCase {
     }
 
     public function test_s3_secret_render_displays_correct_html() {
-        // Simulate the options array and update WordPress option
+        // Simulate the options array and update settings
         $options = ['secret' => 'test-secret'];
-        update_option('s3_media_sync_settings', $options);
+        $this->settings_handler->update_settings($options);
 
         // Start output buffering
         ob_start();
-        $this->s3_media_sync->s3_secret_render();
+        $this->settings_handler->s3_secret_render();
         $output = ob_get_clean();
 
         // Assert the output contains the expected HTML
@@ -42,13 +50,13 @@ class UserInterfaceTest extends TestCase {
     }
 
     public function test_s3_bucket_render_displays_correct_html() {
-        // Simulate the options array and update WordPress option
+        // Simulate the options array and update settings
         $options = ['bucket' => 'test-bucket'];
-        update_option('s3_media_sync_settings', $options);
+        $this->settings_handler->update_settings($options);
 
         // Start output buffering
         ob_start();
-        $this->s3_media_sync->s3_bucket_render();
+        $this->settings_handler->s3_bucket_render();
         $output = ob_get_clean();
 
         // Assert the output contains the expected HTML
@@ -56,13 +64,13 @@ class UserInterfaceTest extends TestCase {
     }
 
     public function test_s3_region_render_displays_correct_html() {
-        // Simulate the options array and update WordPress option
+        // Simulate the options array and update settings
         $options = ['region' => 'test-region'];
-        update_option('s3_media_sync_settings', $options);
+        $this->settings_handler->update_settings($options);
 
         // Start output buffering
         ob_start();
-        $this->s3_media_sync->s3_region_render();
+        $this->settings_handler->s3_region_render();
         $output = ob_get_clean();
 
         // Assert the output contains the expected HTML
@@ -90,13 +98,13 @@ class UserInterfaceTest extends TestCase {
         ];
 
         foreach ($test_cases as $case => $data) {
-            // Simulate the options array and update WordPress option
+            // Simulate the options array and update settings
             $options = ['object_acl' => $data['value']];
-            update_option('s3_media_sync_settings', $options);
+            $this->settings_handler->update_settings($options);
 
             // Start output buffering
             ob_start();
-            $this->s3_media_sync->s3_object_acl_render();
+            $this->settings_handler->s3_object_acl_render();
             $output = ob_get_clean();
 
             // Assert the output contains the expected HTML structure

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -255,31 +255,17 @@ abstract class TestCase extends WPTestCase {
 			'object_acl' => 'public-read',
 		];
 
-		$this->s3_media_sync = S3_Media_Sync::init();
-		$this->settings_handler = $this->s3_media_sync->get_settings_handler();
-		
-		// Initialize settings
-		update_option('s3_media_sync_settings', $this->default_settings);
+		$this->settings_handler = new S3_Media_Sync_Settings();
 		$this->settings_handler->update_settings($this->default_settings);
+		$this->s3_media_sync = new S3_Media_Sync($this->settings_handler);
 	}
 
 	/**
-	 * Nullify the S3_Media_Sync instance after each test.
-	 *
-	 * @throws \ReflectionException If reflection fails.
+	 * Clean up after each test.
 	 */
 	public function tear_down(): void {
 		parent::tear_down();
-
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'instance',
-			null
-		);
-
 		delete_option('s3_media_sync_settings');
-
 		Mockery::close();
 	}
 } 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,18 +7,20 @@
 
 namespace S3_Media_Sync\Tests;
 
-use Yoast\WPTestUtils\WPIntegration\TestCase as WPTestCase;
-use Aws\S3\S3Client;
-use Aws\CommandInterface;
 use Aws\Command;
+use Aws\CommandInterface;
 use Aws\Result;
+use Aws\S3\S3Client;
 use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Utils;
 use Mockery;
+use S3_Media_Sync;
+use S3_Media_Sync_Settings;
+use Yoast\WPTestUtils\WPIntegration\TestCase as WPTestCase;
 
 /**
- * Abstract base class for all test case implementations.
+ * Base test case for S3 Media Sync.
  */
 abstract class TestCase extends WPTestCase {
 	use Tests_Reflection;
@@ -28,20 +30,21 @@ abstract class TestCase extends WPTestCase {
 	 *
 	 * @var \S3_Media_Sync $s3_media_sync The S3_Media_Sync instance.
 	 */
-	protected \S3_Media_Sync $s3_media_sync;
+	protected S3_Media_Sync $s3_media_sync;
 
 	/**
 	 * Default test settings.
 	 *
 	 * @var array
 	 */
-	protected $default_settings = [
-		'bucket'     => 'test-bucket',
-		'key'        => 'test-key',
-		'secret'     => 'test-secret',
-		'region'     => 'test-region',
-		'object_acl' => 'public-read',
-	];
+	protected array $default_settings;
+
+	/**
+	 * Settings handler for the S3_Media_Sync instance.
+	 *
+	 * @var \S3_Media_Sync_Settings_Handler $settings_handler The settings handler.
+	 */
+	protected $settings_handler;
 
 	/**
 	 * Creates a mock S3 client for testing.
@@ -244,9 +247,20 @@ abstract class TestCase extends WPTestCase {
 			require_once dirname( __FILE__, 2 ) . '/vendor/autoload.php';
 		}
 
-		$this->s3_media_sync = \S3_Media_Sync::init();
+		$this->default_settings = [
+			'bucket' => 'test-bucket',
+			'key' => 'test-key',
+			'secret' => 'test-secret',
+			'region' => 'test-region',
+			'object_acl' => 'public-read',
+		];
 
-		remove_action( 'plugins_loaded', [ $this->s3_media_sync, 's3_media_sync_setup' ] );
+		$this->s3_media_sync = S3_Media_Sync::init();
+		$this->settings_handler = $this->s3_media_sync->get_settings_handler();
+		
+		// Initialize settings
+		update_option('s3_media_sync_settings', $this->default_settings);
+		$this->settings_handler->update_settings($this->default_settings);
 	}
 
 	/**
@@ -263,6 +277,8 @@ abstract class TestCase extends WPTestCase {
 			'instance',
 			null
 		);
+
+		delete_option('s3_media_sync_settings');
 
 		Mockery::close();
 	}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -241,9 +241,7 @@ abstract class TestCase extends WPTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
-		// Ensure the AWS SDK can be loaded.
-		if ( ! class_exists( '\\Aws\\S3\\S3Client' ) ) {
-			// Require AWS Autoloader file.
+		if ( file_exists( dirname( __FILE__, 2 ) . '/vendor/autoload.php' ) ) {
 			require_once dirname( __FILE__, 2 ) . '/vendor/autoload.php';
 		}
 


### PR DESCRIPTION
Moves all settings-related code from the `S3_Media_Sync` into the new `S3_Media_Sync_Settings` class. Uses dependency injection to add a reference back in to the former. 

Moves away from using the Singleton pattern on the `S3_Media_Sync` class.

Updates tests to accommodate the changes.

This changes breaks various expected APIs, so the next release will need to be a major release.