### PR TITLE
Extract S3 Client Factory class

### DIFF
--- a/inc/class-s3-media-sync-client-factory.php
+++ b/inc/class-s3-media-sync-client-factory.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * S3 Client Factory
+ *
+ * Creates and configures S3 client instances.
+ *
+ * @package S3_Media_Sync
+ */
+
+use Aws\S3\S3Client;
+use Aws\S3\S3ClientInterface;
+
+/**
+ * Class S3_Media_Sync_Client_Factory
+ *
+ * Factory class for creating configured S3 client instances.
+ *
+ * @since 1.0.0
+ */
+class S3_Media_Sync_Client_Factory {
+
+	/**
+	 * Creates a new S3 client instance with the provided settings.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $settings Array of S3 settings (key, secret, region).
+	 * @return S3ClientInterface Configured S3 client instance.
+	 * @throws \InvalidArgumentException If required settings are missing.
+	 */
+	public function create( array $settings ): S3ClientInterface {
+		if ( empty( $settings['region'] ) ) {
+			throw new \InvalidArgumentException( 'Region is required to create an S3 client.' );
+		}
+
+		$params = [
+			'version' => 'latest',
+			'signature_version' => 'v4',
+			'region' => $settings['region']
+		];
+
+		if ( isset( $settings['key'] ) && isset( $settings['secret'] ) && $settings['key'] && $settings['secret'] ) {
+			$params['credentials'] = [
+				'key'    => $settings['key'],
+				'secret' => $settings['secret']
+			];
+		}
+
+		// Configure proxy if WordPress proxy is defined
+		if ( defined( 'WP_PROXY_HOST' ) && defined( 'WP_PROXY_PORT' ) ) {
+			$proxy_auth = '';
+			$proxy_address = WP_PROXY_HOST . ':' . WP_PROXY_PORT;
+
+			if ( defined( 'WP_PROXY_USERNAME' ) && defined( 'WP_PROXY_PASSWORD' ) ) {
+				$proxy_auth = WP_PROXY_USERNAME . ':' . WP_PROXY_PASSWORD . '@';
+			}
+
+            $params['request.options']['proxy'] = $proxy_auth . $proxy_address;
+
+		}
+
+		return new S3Client( $params );
+	}
+
+	/**
+	 * Configures the stream wrapper with the provided client and settings.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param S3ClientInterface $client The S3 client instance.
+	 * @param array $settings Array of S3 settings.
+	 */
+	public function configure_stream_wrapper( S3ClientInterface $client, array $settings ): void {
+		S3_Media_Sync_Stream_Wrapper::register( $client );
+		$object_acl = isset( $settings['object_acl'] ) ? sanitize_text_field( $settings['object_acl'] ) : 'public-read';
+		stream_context_set_option( stream_context_get_default(), 's3', 'ACL', $object_acl );
+		stream_context_set_option( stream_context_get_default(), 's3', 'seekable', true );
+	}
+} 

--- a/inc/class-s3-media-sync-settings.php
+++ b/inc/class-s3-media-sync-settings.php
@@ -44,8 +44,17 @@ class S3_Media_Sync_Settings {
 		}
 
 		// This check will test the API keys provided
-		$s3_client = new S3_Media_Sync( $this );
-		if ( false === $s3_client->s3()->doesBucketExist( $this->settings['bucket'] ) ) {
+		$factory = new S3_Media_Sync_Client_Factory();
+		try {
+			$s3_client = $factory->create( $this->settings );
+			if ( false === $s3_client->doesBucketExist( $this->settings['bucket'] ) ) {
+				add_settings_error(
+					's3_media_sync_settings',
+					's3-media-sync-settings-error',
+					__( 'The credentials provided are incorrect. The AWS bucket cannot be found.', 's3-media-sync' )
+				);
+			}
+		} catch (\Exception $e) {
 			add_settings_error(
 				's3_media_sync_settings',
 				's3-media-sync-settings-error',

--- a/inc/class-s3-media-sync-settings.php
+++ b/inc/class-s3-media-sync-settings.php
@@ -38,10 +38,41 @@ class S3_Media_Sync_Settings {
 	 * Validate the settings page keys
 	 */
 	public function settings_validation( $input ) {
-		// Only proceed to validate the bucket if all necessary settings are set
-		if ( ! $this->has_required_settings() ) {
-			return $input;
+		$required_keys = [ 'bucket', 'key', 'secret', 'region' ];
+		$missing_keys = [];
+
+		// Check for missing required fields
+		foreach ( $required_keys as $key ) {
+			if ( empty( $input[$key] ) ) {
+				$missing_keys[] = $key;
+			}
 		}
+
+		// If any required fields are missing, add an error and return the old settings
+		if ( !empty($missing_keys) ) {
+			$missing_fields = implode(', ', array_map(function($key) {
+				switch($key) {
+					case 'key': return 'Access Key ID';
+					case 'secret': return 'Secret Access Key';
+					case 'bucket': return 'Bucket Name';
+					case 'region': return 'Region';
+					default: return $key;
+				}
+			}, $missing_keys));
+			
+			add_settings_error(
+				's3_media_sync_settings',
+				's3-media-sync-settings-error',
+				sprintf(
+					__( 'The following required fields are missing: %s', 's3-media-sync' ),
+					$missing_fields
+				)
+			);
+			return $this->settings; // Return old settings
+		}
+
+		// Update the current settings with the new input for validation
+		$this->settings = $input;
 
 		// This check will test the API keys provided
 		$factory = new S3_Media_Sync_Client_Factory();
@@ -53,6 +84,7 @@ class S3_Media_Sync_Settings {
 					's3-media-sync-settings-error',
 					__( 'The credentials provided are incorrect. The AWS bucket cannot be found.', 's3-media-sync' )
 				);
+				return $this->settings; // Return old settings
 			}
 		} catch (\Exception $e) {
 			add_settings_error(
@@ -60,6 +92,7 @@ class S3_Media_Sync_Settings {
 				's3-media-sync-settings-error',
 				__( 'The credentials provided are incorrect. The AWS bucket cannot be found.', 's3-media-sync' )
 			);
+			return $this->settings; // Return old settings
 		}
 
 		return $input;

--- a/s3-media-sync.php
+++ b/s3-media-sync.php
@@ -14,6 +14,7 @@ define( 'S3_MEDIA_SYNC_FILE', __FILE__ );
 require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-settings.php';
 require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync.php';
 require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-stream-wrapper.php';
+require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-client-factory.php';
 
 if ( defined( 'WP_CLI' ) && class_exists( 'WPCOM_VIP_CLI_Command' ) ) {
 	require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-wp-cli.php';

--- a/s3-media-sync.php
+++ b/s3-media-sync.php
@@ -11,6 +11,9 @@
 
 define( 'S3_MEDIA_SYNC_FILE', __FILE__ );
 
+// Load AWS SDK
+require_once dirname( __FILE__ ) . '/vendor/autoload.php';
+
 require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-settings.php';
 require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync.php';
 require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-stream-wrapper.php';

--- a/tests/Integration/BulkOperationsTest.php
+++ b/tests/Integration/BulkOperationsTest.php
@@ -80,22 +80,10 @@ class BulkOperationsTest extends TestCase {
 	 * @param array $test_data The test data.
 	 */
 	public function test_bulk_upload_syncs_to_s3( array $test_data ): void {
-		// Set up the plugin with mock client.
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings',
-			$this->default_settings
-		);
-
+		// Create a mock S3 client
 		$s3_client = $this->create_mock_s3_client();
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			's3',
-			$s3_client
-		);
 
+		// Set up the plugin
 		$this->s3_media_sync->setup();
 
 		$test_files = [];
@@ -140,27 +128,14 @@ class BulkOperationsTest extends TestCase {
 	 * @dataProvider data_provider_bulk_operations
 	 */
 	public function test_bulk_upload_error_handling( array $test_data ): void {
-		// Set up the plugin with mock client that will fail uploads.
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings',
-			$this->default_settings
-		);
-
+		// Create a mock S3 client that will fail uploads
 		$s3_client = $this->create_mock_s3_client([
 			'error_code' => 'AccessDenied',
 			'error_message' => 'Access Denied',
 			'should_succeed' => false
 		]);
 
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			's3',
-			$s3_client
-		);
-
+		// Set up the plugin
 		$this->s3_media_sync->setup();
 
 		$test_files = [];

--- a/tests/Integration/ClientFactoryTest.php
+++ b/tests/Integration/ClientFactoryTest.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * Integration tests for S3 Media Sync client factory
+ *
+ * @package S3_Media_Sync
+ */
+
+namespace S3_Media_Sync\Tests\Integration;
+
+use Aws\S3\S3Client;
+use Aws\S3\S3ClientInterface;
+use PHPUnit\Framework\Assert;
+use S3_Media_Sync\Tests\TestCase;
+use S3_Media_Sync_Client_Factory;
+use S3_Media_Sync_Stream_Wrapper;
+use S3_Media_Sync;
+use S3_Media_Sync_Settings;
+
+/**
+ * Test case for S3 Media Sync client factory functionality.
+ *
+ * @group integration
+ * @group client-factory
+ * @covers \S3_Media_Sync_Client_Factory
+ * @uses \S3_Media_Sync_Stream_Wrapper
+ * @uses \S3_Media_Sync
+ * @uses \S3_Media_Sync_Settings
+ */
+class ClientFactoryTest extends TestCase {
+
+    /**
+     * @var S3_Media_Sync_Client_Factory
+     */
+    protected $factory;
+
+    /**
+     * Set up before each test.
+     */
+    public function set_up(): void {
+        parent::set_up();
+        $this->factory = new S3_Media_Sync_Client_Factory();
+    }
+
+    /**
+     * Test data for client creation scenarios.
+     *
+     * @return array[] Array of test data.
+     */
+    public function data_provider_client_settings(): array {
+        return [
+            'complete settings' => [
+                [
+                    'key' => 'test-key',
+                    'secret' => 'test-secret',
+                    'region' => 'test-region',
+                    'object_acl' => 'public-read',
+                ],
+                true,
+                true,
+            ],
+            'minimal settings' => [
+                [
+                    'region' => 'test-region',
+                ],
+                false,
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * Test client creation with different settings.
+     *
+     * @dataProvider data_provider_client_settings
+     * 
+     * @param array $settings The settings to test with.
+     * @param bool  $has_credentials Whether credentials should be present.
+     * @param bool  $has_region Whether region should be present.
+     */
+    public function test_create_client(array $settings, bool $has_credentials, bool $has_region): void {
+        $client = $this->factory->create($settings);
+
+        Assert::assertInstanceOf(S3ClientInterface::class, $client, 'Factory should create an S3 client instance');
+
+        if ($has_credentials) {
+            $credentials = $client->getCredentials()->wait();
+            Assert::assertSame($settings['key'], $credentials->getAccessKeyId(), 'Client should have correct access key');
+            Assert::assertSame($settings['secret'], $credentials->getSecretKey(), 'Client should have correct secret key');
+        }
+
+        if ($has_region) {
+            $region = $client->getRegion();
+            Assert::assertSame($settings['region'], $region, 'Client should have correct region');
+        }
+    }
+
+    /**
+     * Test that client creation fails without required settings.
+     */
+    public function test_create_client_fails_without_region(): void {
+        $settings = [
+            'key' => 'test-key',
+            'secret' => 'test-secret',
+        ];
+
+        $exception_thrown = false;
+        try {
+            $this->factory->create($settings);
+        } catch (\InvalidArgumentException $e) {
+            $exception_thrown = true;
+            Assert::assertStringContainsStringIgnoringCase('region', $e->getMessage(), 'Exception should mention missing region');
+        }
+        Assert::assertTrue($exception_thrown, 'Expected InvalidArgumentException was not thrown');
+    }
+
+    /**
+     * Test data for stream wrapper configuration scenarios.
+     *
+     * @return array[] Array of test data.
+     */
+    public function data_provider_stream_wrapper_settings(): array {
+        return [
+            'complete settings' => [
+                [
+                    'region' => 'test-region',
+                    'object_acl' => 'private',
+                ],
+                'private',
+            ],
+            'default acl' => [
+                [
+                    'region' => 'test-region',
+                ],
+                'public-read',
+            ],
+            'custom acl' => [
+                [
+                    'region' => 'test-region',
+                    'object_acl' => 'authenticated-read',
+                ],
+                'authenticated-read',
+            ],
+            'sanitized acl' => [
+                [
+                    'region' => 'test-region',
+                    'object_acl' => '<script>alert("xss")</script>public-read',
+                ],
+                'public-read',
+            ],
+        ];
+    }
+
+    /**
+     * Test stream wrapper configuration with different settings.
+     *
+     * @dataProvider data_provider_stream_wrapper_settings
+     * 
+     * @param array  $settings     The settings to test with.
+     * @param string $expected_acl The expected ACL setting.
+     */
+    public function test_stream_wrapper_configuration(array $settings, string $expected_acl): void {
+        $client = $this->factory->create($settings);
+        $this->factory->configure_stream_wrapper($client, $settings);
+
+        Assert::assertContains('s3', stream_get_wrappers(), 'Stream wrapper should be registered');
+
+        $context = stream_context_get_default();
+        $s3_options = stream_context_get_options($context)['s3'] ?? [];
+
+        Assert::assertSame($expected_acl, $s3_options['ACL'], 'Stream wrapper should have correct ACL');
+        Assert::assertTrue($s3_options['seekable'], 'Stream wrapper should be seekable');
+    }
+
+    /**
+     * Test client creation with empty credentials.
+     */
+    public function test_create_client_with_empty_credentials(): void {
+        $settings = [
+            'region' => 'test-region',
+            'key' => '',
+            'secret' => '',
+        ];
+
+        $client = $this->factory->create($settings);
+        Assert::assertInstanceOf(S3ClientInterface::class, $client, 'Factory should create an S3 client instance');
+
+        $config = $client->getConfig();
+        Assert::assertArrayNotHasKey('credentials', $config, 'Client should not have empty credentials configured');
+    }
+
+    /**
+     * Test client creation with partial credentials.
+     */
+    public function test_create_client_with_partial_credentials(): void {
+        $settings = [
+            'region' => 'test-region',
+            'key' => 'test-key',
+            // Missing secret
+        ];
+
+        $client = $this->factory->create($settings);
+        Assert::assertInstanceOf(S3ClientInterface::class, $client, 'Factory should create an S3 client instance');
+
+        $config = $client->getConfig();
+        Assert::assertArrayNotHasKey('credentials', $config, 'Client should not have partial credentials configured');
+    }
+
+    /**
+     * Test client creation with invalid region.
+     */
+    public function test_create_client_with_empty_region(): void {
+        $settings = [
+            'region' => '',
+            'key' => 'test-key',
+            'secret' => 'test-secret',
+        ];
+
+        $exception_thrown = false;
+        try {
+            $this->factory->create($settings);
+        } catch (\InvalidArgumentException $e) {
+            $exception_thrown = true;
+            Assert::assertStringContainsStringIgnoringCase('region', $e->getMessage(), 'Exception should mention missing region');
+        }
+        Assert::assertTrue($exception_thrown, 'Expected InvalidArgumentException was not thrown');
+    }
+
+    /**
+     * Test data for proxy configuration scenarios.
+     *
+     * @return array[] Array of test data.
+     */
+    public function data_provider_proxy_settings(): array {
+        return [
+            'with authentication' => [
+                [
+                    'host' => 'proxy.example.com',
+                    'port' => '8080',
+                    'username' => 'user',
+                    'password' => 'pass',
+                ],
+                'user:pass@proxy.example.com:8080',
+            ],
+            'without authentication' => [
+                [
+                    'host' => 'proxy.example.com',
+                    'port' => '8080',
+                ],
+                'proxy.example.com:8080',
+            ],
+        ];
+    }
+
+    /**
+     * Test proxy configuration with different settings.
+     *
+     * @dataProvider data_provider_proxy_settings
+     * 
+     * @param array  $proxy_settings The proxy settings to test.
+     * @param string $expected_proxy The expected proxy string.
+     */
+    public function test_proxy_configuration(array $proxy_settings, string $expected_proxy): void {
+        $proxy_auth = '';
+        $proxy_address = $proxy_settings['host'] . ':' . $proxy_settings['port'];
+
+        if (isset($proxy_settings['username']) && isset($proxy_settings['password'])) {
+            $proxy_auth = $proxy_settings['username'] . ':' . $proxy_settings['password'] . '@';
+        }
+
+        $expected_proxy_string = $proxy_auth . $proxy_address;
+        Assert::assertSame($expected_proxy, $expected_proxy_string, 'Proxy string should be correctly formatted');
+    }
+
+    /**
+     * Test client creation with WordPress proxy configuration.
+     */
+    public function test_create_client_with_wordpress_proxy(): void {
+        if (!defined('WP_PROXY_HOST')) {
+            define('WP_PROXY_HOST', 'proxy.example.com');
+            define('WP_PROXY_PORT', '8080');
+            define('WP_PROXY_USERNAME', 'user');
+            define('WP_PROXY_PASSWORD', 'pass');
+        }
+
+        $settings = [
+            'region' => 'test-region',
+        ];
+
+        $client = $this->factory->create($settings);
+        Assert::assertInstanceOf(S3ClientInterface::class, $client);
+
+        // Test that the client was created with the correct region
+        Assert::assertSame('test-region', $client->getRegion());
+    }
+
+    /**
+     * Test client creation with WordPress proxy configuration without authentication.
+     */
+    public function test_create_client_with_wordpress_proxy_without_auth(): void {
+        if (!defined('WP_PROXY_HOST')) {
+            define('WP_PROXY_HOST', 'proxy.example.com');
+            define('WP_PROXY_PORT', '8080');
+        }
+
+        $settings = [
+            'region' => 'test-region',
+        ];
+
+        $client = $this->factory->create($settings);
+        Assert::assertInstanceOf(S3ClientInterface::class, $client);
+
+        // Test that the client was created with the correct region
+        Assert::assertSame('test-region', $client->getRegion());
+    }
+
+    /**
+     * Test client creation without WordPress proxy configuration.
+     */
+    public function test_create_client_without_wordpress_proxy(): void {
+        $settings = [
+            'region' => 'test-region',
+        ];
+
+        $client = $this->factory->create($settings);
+        Assert::assertInstanceOf(S3ClientInterface::class, $client);
+
+        // Test that the client was created with the correct region
+        Assert::assertSame('test-region', $client->getRegion());
+    }
+
+    /**
+     * Clean up after each test.
+     */
+    public function tear_down(): void {
+        parent::tear_down();
+        
+        // Clean up stream wrapper registration
+        if (in_array('s3', stream_get_wrappers(), true)) {
+            stream_wrapper_unregister('s3');
+        }
+    }
+} 

--- a/tests/Integration/ErrorHandlingTest.php
+++ b/tests/Integration/ErrorHandlingTest.php
@@ -64,21 +64,15 @@ class ErrorHandlingTest extends TestCase {
 	 * @dataProvider data_provider_error_scenarios
 	 */
 	public function test_error_handling_during_operations($error_code, $error_message) {
+		// Create a mock S3 client that will fail operations
 		$s3_client = $this->create_mock_s3_client([
 			'error_code' => $error_code,
 			'error_message' => $error_message,
 			'should_succeed' => false
 		]);
 
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			's3',
-			$s3_client
-		);
-
-		// Register the stream wrapper
-		$this->s3_media_sync->register_stream_wrapper();
+		// Set up the plugin
+		$this->s3_media_sync->setup();
 
 		$upload = $this->create_test_upload($this->test_file);
 		
@@ -98,21 +92,15 @@ class ErrorHandlingTest extends TestCase {
 	 * @dataProvider data_provider_error_scenarios
 	 */
 	public function test_stream_wrapper_error_handling($error_code, $error_message) {
+		// Create a mock S3 client that will fail operations
 		$s3_client = $this->create_mock_s3_client([
 			'error_code' => $error_code,
 			'error_message' => $error_message,
 			'should_succeed' => false
 		]);
 
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			's3',
-			$s3_client
-		);
-
-		// Register the stream wrapper
-		$this->s3_media_sync->register_stream_wrapper();
+		// Set up the plugin
+		$this->s3_media_sync->setup();
 
 		$s3_path = 's3://' . $this->default_settings['bucket'] . '/test.txt';
 		

--- a/tests/Integration/FileDeleteTest.php
+++ b/tests/Integration/FileDeleteTest.php
@@ -62,25 +62,16 @@ class FileDeleteTest extends TestCase {
 	 * @param array $test_data The test data.
 	 */
 	public function test_delete_attachment_from_s3( array $test_data ): void {
-		// Set up the plugin with mock client
-		$settings = $this->default_settings;
-		$settings['bucket'] = $test_data['bucket'];
+		// Update settings with test bucket
+		$this->settings_handler->update_settings(array_merge(
+			$this->default_settings,
+			['bucket' => $test_data['bucket']]
+		));
 
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings',
-			$settings
-		);
-
+		// Create a mock S3 client
 		$s3_client = $this->create_mock_s3_client();
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			's3',
-			$s3_client
-		);
 
+		// Set up the plugin
 		$this->s3_media_sync->setup();
 
 		// Create a test file and simulate WordPress upload
@@ -135,30 +126,20 @@ class FileDeleteTest extends TestCase {
 	 * @dataProvider data_provider_file_deletions
 	 */
 	public function test_delete_attachment_error_handling( array $test_data ): void {
-		// Set up the plugin with mock client that will fail deletions
-		$settings = $this->default_settings;
-		$settings['bucket'] = $test_data['bucket'];
+		// Update settings with test bucket
+		$this->settings_handler->update_settings(array_merge(
+			$this->default_settings,
+			['bucket' => $test_data['bucket']]
+		));
 
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings',
-			$settings
-		);
-
+		// Create a mock S3 client that will fail deletions
 		$s3_client = $this->create_mock_s3_client([
 			'error_code' => 'AccessDenied',
 			'error_message' => 'Access Denied',
 			'should_succeed' => false
 		]);
 
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			's3',
-			$s3_client
-		);
-
+		// Set up the plugin
 		$this->s3_media_sync->setup();
 
 		// Create a test file and simulate WordPress upload

--- a/tests/Integration/ImageEditorTest.php
+++ b/tests/Integration/ImageEditorTest.php
@@ -83,21 +83,8 @@ class ImageEditorTest extends TestCase {
 	 */
 	public function test_image_editor_changes_sync_to_s3( array $test_data ): void {
 		// Set up the plugin with mock client.
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings',
-			$this->default_settings
-		);
-
-		$s3_client = $this->create_mock_s3_client();
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			's3',
-			$s3_client
-		);
-
+		$this->settings_handler->update_settings($this->default_settings);
+		$this->create_mock_s3_client();
 		$this->s3_media_sync->setup();
 
 		// Create a temporary test file with specific content.
@@ -199,26 +186,12 @@ class ImageEditorTest extends TestCase {
 	 */
 	public function test_image_editor_error_handling(array $test_data): void {
 		// Set up the plugin with mock client that will fail uploads.
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings',
-			$this->default_settings
-		);
-
-		$s3_client = $this->create_mock_s3_client([
+		$this->settings_handler->update_settings($this->default_settings);
+		$this->create_mock_s3_client([
 			'error_code' => 'AccessDenied',
 			'error_message' => 'Access Denied',
 			'should_succeed' => false
 		]);
-
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			's3',
-			$s3_client
-		);
-
 		$this->s3_media_sync->setup();
 
 		// Create a temporary test file.

--- a/tests/Integration/MediaUploadTest.php
+++ b/tests/Integration/MediaUploadTest.php
@@ -68,21 +68,8 @@ class MediaUploadTest extends TestCase {
 	 */
 	public function test_media_upload_syncs_to_s3( array $test_data ): void {
 		// Set up the plugin with mock client.
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings',
-			$this->default_settings
-		);
-
-		$s3_client = $this->create_mock_s3_client();
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			's3',
-			$s3_client
-		);
-
+		$this->settings_handler->update_settings($this->default_settings);
+		$this->create_mock_s3_client();
 		$this->s3_media_sync->setup();
 
 		// Create a temporary test file with specific content.
@@ -117,26 +104,12 @@ class MediaUploadTest extends TestCase {
 	 */
 	public function test_media_upload_error_handling(array $test_data): void {
 		// Set up the plugin with mock client that will fail uploads.
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			'settings',
-			$this->default_settings
-		);
-
-		$s3_client = $this->create_mock_s3_client([
+		$this->settings_handler->update_settings($this->default_settings);
+		$this->create_mock_s3_client([
 			'error_code' => 'AccessDenied',
 			'error_message' => 'Access Denied',
 			'should_succeed' => false
 		]);
-
-		$this::set_private_property(
-			$this->s3_media_sync::class,
-			$this->s3_media_sync,
-			's3',
-			$s3_client
-		);
-
 		$this->s3_media_sync->setup();
 
 		// Create a temporary test file.

--- a/tests/Integration/SettingsTest.php
+++ b/tests/Integration/SettingsTest.php
@@ -107,14 +107,7 @@ class SettingsTest extends TestCase {
 
 		$admin_error_codes = wp_list_pluck( get_settings_errors(), 'code' );
 
-		if ( $should_validate ) {
-			Assert::assertContains( $error_code, $admin_error_codes, 'Settings validation should have failed' );
-		} else {
-			Assert::assertEmpty( $admin_error_codes, 'No validation errors should be present for empty settings' );
-		}
-
-		// Clean up
-		delete_option( 's3_media_sync_settings' );
+		Assert::assertContains( $error_code, $admin_error_codes, 'Settings validation should have failed' );
 	}
 
 	/**


### PR DESCRIPTION
⚠️ Do not merge as is. Once #39 has been merged, this PR can be updated to be against `develop` branch ⚠️ 

This PR was extended from `feature/settings-class`.

- Create new `S3_Media_Sync_Client_Factory` class to centralize S3 client creation
- Refactor S3 client initialization in main plugin class - decouples S3 client creation from the existing "god class".
- Add support for WordPress proxy configuration in client creation
- Improve error handling and client configuration flexibility
- Update tests to work with new client factory approach