### PR TITLE
WP-CLI: Add new commands

### DIFF
--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -256,6 +256,92 @@ class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 		WP_CLI::success( sprintf( 'Successfully deleted %s', $prefix ) );
 	}
 
+	/**
+	 * Get status information about the S3 connection and plugin configuration
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Check S3 connection status and configuration
+	 *     $ wp s3-media status
+	 */
+	public function status( $args, $assoc_args ) {
+		$s3 = $this->get_s3_media_sync();
+		$settings_handler = $s3->get_settings_handler();
+		$settings = $settings_handler->get_settings();
+		
+		// Check if required settings are available
+		if ( ! $settings_handler->has_required_settings() ) {
+			WP_CLI::error( 'S3 Media Sync is not properly configured. Please set up your AWS credentials in the WordPress admin.' );
+			return;
+		}
+		
+		// Check S3 connection
+		try {
+			$bucket = $s3->get_s3_bucket();
+			$bucket_parts = explode( '/', $bucket, 2 );
+			$bucket_name = $bucket_parts[0];
+			
+			// Get the S3 client
+			$s3_client = $s3->get_s3_client();
+			
+			// Check bucket accessibility by performing a head bucket request
+			$s3_client->headBucket( array(
+				'Bucket' => $bucket_name
+			) );
+			
+			// Display configuration information
+			WP_CLI::success( 'Successfully connected to S3' );
+			
+			// Create a formatted table of settings
+			$settings_data = array();
+			$settings_data[] = array(
+				'Setting' => 'Bucket',
+				'Value' => $bucket
+			);
+			$settings_data[] = array(
+				'Setting' => 'Region',
+				'Value' => $settings['region']
+			);
+			$settings_data[] = array(
+				'Setting' => 'Use ACLs',
+				'Value' => isset( $settings['use_acl'] ) && $settings['use_acl'] ? 'Yes' : 'No'
+			);
+			$settings_data[] = array(
+				'Setting' => 'Object ACL',
+				'Value' => isset( $settings['object_acl'] ) ? $settings['object_acl'] : 'Not set'
+			);
+			$settings_data[] = array(
+				'Setting' => 'Sync Thumbnails',
+				'Value' => isset( $settings['sync_thumbnails'] ) && $settings['sync_thumbnails'] !== false ? 'Yes' : 'No'
+			);
+			
+			// Display table
+			WP_CLI\Utils\format_items( 'table', $settings_data, array( 'Setting', 'Value' ) );
+			
+			// List IAM user/role details if possible
+			try {
+				$sts_client = new \Aws\Sts\StsClient([
+					'region' => $settings['region'],
+					'version' => 'latest',
+					'credentials' => [
+						'key' => $settings['key'],
+						'secret' => $settings['secret']
+					]
+				]);
+				$identity = $sts_client->getCallerIdentity();
+				
+				WP_CLI::line( '' ); // Empty line for spacing
+				WP_CLI::line( 'AWS Account Information:' );
+				WP_CLI::line( '- Account ID: ' . $identity['Account'] );
+				WP_CLI::line( '- IAM User/Role: ' . $identity['Arn'] );
+			} catch ( \Exception $e ) {
+				WP_CLI::warning( 'Unable to retrieve AWS identity information: ' . $e->getMessage() );
+			}
+			
+		} catch ( \Exception $e ) {
+			WP_CLI::error( sprintf( 'Failed to connect to S3: %s', $e->getMessage() ) );
+		}
+	}
 
 	/**
 	 * Reset the local WordPress object cache.

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -18,7 +18,7 @@ use \WP_CLI\Utils;
  *     # Remove files from S3.
  *     $ wp s3-media rm <path> [--regex=<regex>]
  */
-class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
+class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 
 	/**
 	 * Upload a single attachment to S3
@@ -187,7 +187,8 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 				}
 			}
 			// Pause and clear caches to free up memory
-			$this->vip_inmemory_cleanup();
+			$this->reset_local_object_cache();
+			$this->reset_db_query_log();
 			sleep( 1 );
 			$offset += $limit;
 		} while ( count( $attachments ) );
@@ -252,6 +253,45 @@ class S3_Media_Sync_WP_CLI_Command extends WPCOM_VIP_CLI_Command {
 		}
 		WP_CLI::success( sprintf( 'Successfully deleted %s', $prefix ) );
 	}
-}
 
-WP_CLI::add_command( 's3-media', 'S3_Media_Sync_WP_CLI_Command' );
+
+	/**
+	 * Reset the local WordPress object cache.
+	 *
+	 * This only cleans the local cache in WP_Object_Cache, without
+	 * affecting memcache.
+	 */
+	private function reset_local_object_cache() {
+		global $wp_object_cache;
+
+		if ( ! is_object( $wp_object_cache ) ) {
+			return;
+		}
+
+		$properties = [
+			'group_ops',
+			'memcache_debug',
+			'cache',
+		];
+
+		foreach ( $properties as $property ) {
+			if ( property_exists( $wp_object_cache, $property ) ) {
+				$wp_object_cache->$property = [];
+			}
+		}
+
+		if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
+			$wp_object_cache->__remoteset(); // important
+		}
+	}
+
+	/**
+	 * Reset the WordPress DB query log.
+	 */
+	private function reset_db_query_log() {
+		global $wpdb;
+
+		$wpdb->queries = array();
+	}
+
+}

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -416,9 +416,9 @@ class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 		
 		// Get a batch of attachments
 		$sql = $wpdb->prepare(
-			"SELECT ID, post_title FROM wp_posts 
-			WHERE post_type = 'attachment' 
-			ORDER BY ID 
+			"SELECT ID, post_title FROM {$wpdb->posts}
+			WHERE post_type = 'attachment'
+			ORDER BY ID
 			LIMIT %d OFFSET %d",
 			$limit, $offset
 		);
@@ -490,18 +490,9 @@ class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 					$count_size_mismatch++;
 					
 					if ( $fix ) {
-						// Upload the corrected file
-						try {
-							$s3_client->putObject([
-								'Bucket' => $bucket_name,
-								'Key' => $prefix . $s3_key,
-								'SourceFile' => $local_file_path,
-								'ACL' => 'public-read',
-							]);
+						$is_fixed = $this->upload_file_to_s3( $s3_client, $bucket_name, $prefix . $s3_key, $local_file_path );
+						if ( $is_fixed ) {
 							$count_fixed++;
-							$is_fixed = true;
-						} catch ( \Exception $upload_e ) {
-							// Failed to fix
 						}
 					}
 				}
@@ -511,44 +502,26 @@ class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 					if ( $s3_etag !== $local_md5 ) {
 						$issue_type = 'MD5 mismatch';
 						$count_md5_mismatch++;
-						
+
 						if ( $fix ) {
-							// Upload the corrected file
-							try {
-								$s3_client->putObject([
-									'Bucket' => $bucket_name,
-									'Key' => $prefix . $s3_key,
-									'SourceFile' => $local_file_path,
-									'ACL' => 'public-read',
-								]);
+							$is_fixed = $this->upload_file_to_s3( $s3_client, $bucket_name, $prefix . $s3_key, $local_file_path );
+							if ( $is_fixed ) {
 								$count_fixed++;
-								$is_fixed = true;
-							} catch ( \Exception $upload_e ) {
-								// Failed to fix
 							}
 						}
 					}
 				}
-				
+
 			} catch ( \Exception $e ) {
 				// File doesn't exist on S3
 				$s3_exists = false;
 				$issue_type = 'Missing on S3';
 				$count_missing++;
-				
+
 				if ( $fix ) {
-					// Upload the missing file
-					try {
-						$s3_client->putObject([
-							'Bucket' => $bucket_name,
-							'Key' => $prefix . $s3_key,
-							'SourceFile' => $local_file_path,
-							'ACL' => 'public-read',
-						]);
+					$is_fixed = $this->upload_file_to_s3( $s3_client, $bucket_name, $prefix . $s3_key, $local_file_path );
+					if ( $is_fixed ) {
 						$count_fixed++;
-						$is_fixed = true;
-					} catch ( \Exception $upload_e ) {
-						// Failed to fix
 					}
 				}
 			}
@@ -992,15 +965,50 @@ class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 	/**
 	 * Get the S3 Media Sync instance.
 	 *
+	 * @since 2.0.0
+	 *
 	 * @return S3_Media_Sync
 	 */
 	private function get_s3_media_sync() {
 		$settings_handler = new S3_Media_Sync_Settings();
-		$settings = $settings_handler->get_settings();
-		$tester = new S3_Media_Sync_Tester($settings);
-		$s3_media_sync = new S3_Media_Sync($settings_handler);
+		$s3_media_sync    = new S3_Media_Sync( $settings_handler );
 		$s3_media_sync->setup();
 		return $s3_media_sync;
+	}
+
+	/**
+	 * Upload a file to S3 with proper ACL handling.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param \Aws\S3\S3Client $s3_client      The S3 client.
+	 * @param string           $bucket_name    The bucket name.
+	 * @param string           $key            The S3 object key.
+	 * @param string           $source_file    The local file path.
+	 * @return bool Whether the upload succeeded.
+	 */
+	private function upload_file_to_s3( $s3_client, $bucket_name, $key, $source_file ) {
+		$settings_handler = new S3_Media_Sync_Settings();
+		$settings         = $settings_handler->get_settings();
+
+		$params = [
+			'Bucket'     => $bucket_name,
+			'Key'        => $key,
+			'SourceFile' => $source_file,
+		];
+
+		// Only add ACL if the setting is enabled
+		if ( isset( $settings['use_acl'] ) && $settings['use_acl'] ) {
+			$params['ACL'] = isset( $settings['object_acl'] ) ? $settings['object_acl'] : 'public-read';
+		}
+
+		try {
+			$s3_client->putObject( $params );
+			return true;
+		} catch ( \Exception $e ) {
+			WP_CLI::warning( sprintf( 'Failed to upload %s: %s', $source_file, $e->getMessage() ) );
+			return false;
+		}
 	}
 
 }

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -344,6 +344,265 @@ class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Verify local media files against S3
+	 *
+	 * @synopsis [--verify-size] [--verify-md5] [--fix] [--limit=<number>] [--offset=<number>]
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--verify-size]
+	 * : Whether to verify file sizes match
+	 * ---
+	 * default: true
+	 * ---
+	 *
+	 * [--verify-md5]
+	 * : Whether to verify MD5 checksums match (slower but more accurate)
+	 * ---
+	 * default: false
+	 * ---
+	 *
+	 * [--fix]
+	 * : Automatically upload files that don't match or don't exist on S3
+	 * ---
+	 * default: false
+	 * ---
+	 * 
+	 * [--limit=<number>]
+	 * : Limit the number of attachments to verify
+	 * ---
+	 * default: 100
+	 * ---
+	 *
+	 * [--offset=<number>]
+	 * : Number of attachments to skip
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Verify file existence and size for 100 attachments
+	 *     $ wp s3-media verify
+	 *
+	 *     # Verify file existence, size, and MD5 checksums, fixing any issues
+	 *     $ wp s3-media verify --verify-md5 --fix
+	 *
+	 *     # Verify a specific batch of attachments
+	 *     $ wp s3-media verify --limit=50 --offset=200
+	 */
+	public function verify( $args, $assoc_args ) {
+		global $wpdb;
+		
+		// Parse arguments
+		$verify_size = isset( $assoc_args['verify-size'] ) ? filter_var( $assoc_args['verify-size'], FILTER_VALIDATE_BOOLEAN ) : true;
+		$verify_md5 = isset( $assoc_args['verify-md5'] ) ? filter_var( $assoc_args['verify-md5'], FILTER_VALIDATE_BOOLEAN ) : false;
+		$fix = isset( $assoc_args['fix'] ) ? filter_var( $assoc_args['fix'], FILTER_VALIDATE_BOOLEAN ) : false;
+		$limit = isset( $assoc_args['limit'] ) ? absint( $assoc_args['limit'] ) : 100;
+		$offset = isset( $assoc_args['offset'] ) ? absint( $assoc_args['offset'] ) : 0;
+		
+		// Get S3 client and bucket info
+		$s3 = $this->get_s3_media_sync();
+		$s3_client = $s3->get_s3_client();
+		$bucket = $s3->get_s3_bucket();
+		$bucket_parts = explode( '/', $bucket, 2 );
+		$bucket_name = $bucket_parts[0];
+		$prefix = isset( $bucket_parts[1] ) ? trailingslashit( $bucket_parts[1] ) : '';
+		
+		// Get uploads directory info
+		$uploads = wp_upload_dir();
+		$base_dir = $uploads['basedir'];
+		$base_url = $uploads['baseurl'];
+		
+		// Get a batch of attachments
+		$sql = $wpdb->prepare(
+			"SELECT ID, post_title FROM wp_posts 
+			WHERE post_type = 'attachment' 
+			ORDER BY ID 
+			LIMIT %d OFFSET %d",
+			$limit, $offset
+		);
+		
+		$attachments = $wpdb->get_results( $sql );
+		
+		if ( empty( $attachments ) ) {
+			WP_CLI::warning( 'No attachments found.' );
+			return;
+		}
+		
+		// Initialize counters
+		$count_total = count( $attachments );
+		$count_missing = 0;
+		$count_size_mismatch = 0;
+		$count_md5_mismatch = 0;
+		$count_fixed = 0;
+		
+		// Set up progress bar
+		$progress = \WP_CLI\Utils\make_progress_bar( sprintf( 'Verifying %d attachments', $count_total ), $count_total );
+		
+		// Track verification details
+		$verification_issues = array();
+		
+		foreach ( $attachments as $attachment ) {
+			$attachment_id = $attachment->ID;
+			$attachment_url = wp_get_attachment_url( $attachment_id );
+			
+			if ( empty( $attachment_url ) ) {
+				$progress->tick();
+				continue;
+			}
+			
+			// Get file path information
+			$relative_url_path = str_replace( $base_url, '', $attachment_url );
+			$local_file_path = $base_dir . $relative_url_path;
+			$s3_key = 'wp-content/uploads' . $relative_url_path;
+			
+			// Skip if local file doesn't exist
+			if ( ! file_exists( $local_file_path ) ) {
+				$progress->tick();
+				continue;
+			}
+			
+			// Get local file information
+			$local_size = filesize( $local_file_path );
+			$local_md5 = $verify_md5 ? md5_file( $local_file_path ) : '';
+			
+			// Check if file exists in S3
+			$s3_exists = false;
+			$s3_size = 0;
+			$s3_etag = '';
+			$issue_type = '';
+			$is_fixed = false;
+			
+			try {
+				$s3_object = $s3_client->headObject([
+					'Bucket' => $bucket_name,
+					'Key' => $prefix . $s3_key,
+				]);
+				
+				$s3_exists = true;
+				$s3_size = isset( $s3_object['ContentLength'] ) ? $s3_object['ContentLength'] : 0;
+				$s3_etag = isset( $s3_object['ETag'] ) ? trim( $s3_object['ETag'], '"' ) : '';
+				
+				// Check size if requested
+				if ( $verify_size && $s3_size != $local_size ) {
+					$issue_type = 'Size mismatch';
+					$count_size_mismatch++;
+					
+					if ( $fix ) {
+						// Upload the corrected file
+						try {
+							$s3_client->putObject([
+								'Bucket' => $bucket_name,
+								'Key' => $prefix . $s3_key,
+								'SourceFile' => $local_file_path,
+								'ACL' => 'public-read',
+							]);
+							$count_fixed++;
+							$is_fixed = true;
+						} catch ( \Exception $upload_e ) {
+							// Failed to fix
+						}
+					}
+				}
+				// Check MD5 if requested and there's no size mismatch
+				elseif ( $verify_md5 && empty( $issue_type ) ) {
+					// S3 ETags are MD5 hashes for non-multipart uploads
+					if ( $s3_etag !== $local_md5 ) {
+						$issue_type = 'MD5 mismatch';
+						$count_md5_mismatch++;
+						
+						if ( $fix ) {
+							// Upload the corrected file
+							try {
+								$s3_client->putObject([
+									'Bucket' => $bucket_name,
+									'Key' => $prefix . $s3_key,
+									'SourceFile' => $local_file_path,
+									'ACL' => 'public-read',
+								]);
+								$count_fixed++;
+								$is_fixed = true;
+							} catch ( \Exception $upload_e ) {
+								// Failed to fix
+							}
+						}
+					}
+				}
+				
+			} catch ( \Exception $e ) {
+				// File doesn't exist on S3
+				$s3_exists = false;
+				$issue_type = 'Missing on S3';
+				$count_missing++;
+				
+				if ( $fix ) {
+					// Upload the missing file
+					try {
+						$s3_client->putObject([
+							'Bucket' => $bucket_name,
+							'Key' => $prefix . $s3_key,
+							'SourceFile' => $local_file_path,
+							'ACL' => 'public-read',
+						]);
+						$count_fixed++;
+						$is_fixed = true;
+					} catch ( \Exception $upload_e ) {
+						// Failed to fix
+					}
+				}
+			}
+			
+			// Record verification issues
+			if ( ! empty( $issue_type ) ) {
+				$verification_issues[] = array(
+					'ID' => $attachment_id,
+					'Title' => $attachment->post_title,
+					'Issue' => $issue_type,
+					'Local Size' => size_format( $local_size, 2 ),
+					'S3 Size' => $s3_exists ? size_format( $s3_size, 2 ) : 'N/A',
+					'Fixed' => $is_fixed ? 'Yes' : 'No',
+				);
+			}
+			
+			$progress->tick();
+		}
+		
+		$progress->finish();
+		
+		// Report results
+		WP_CLI::line( '' );
+		WP_CLI::line( 'Verification Results:' );
+		WP_CLI::line( sprintf( 'Total attachments: %d', $count_total ) );
+		WP_CLI::line( sprintf( 'Missing on S3: %d', $count_missing ) );
+		WP_CLI::line( sprintf( 'Size mismatches: %d', $count_size_mismatch ) );
+		
+		if ( $verify_md5 ) {
+			WP_CLI::line( sprintf( 'MD5 mismatches: %d', $count_md5_mismatch ) );
+		}
+		
+		if ( $fix ) {
+			WP_CLI::line( sprintf( 'Issues fixed: %d', $count_fixed ) );
+		}
+		
+		// Display issues in a table
+		if ( ! empty( $verification_issues ) ) {
+			WP_CLI::line( '' );
+			WP_CLI::line( 'Issues found:' );
+			
+			$table_fields = array( 'ID', 'Title', 'Issue', 'Local Size', 'S3 Size' );
+			
+			if ( $fix ) {
+				$table_fields[] = 'Fixed';
+			}
+			
+			WP_CLI\Utils\format_items( 'table', $verification_issues, $table_fields );
+		} else {
+			WP_CLI::success( 'All verified files are in sync with S3.' );
+		}
+	}
+
+	/**
 	 * Reset the local WordPress object cache.
 	 *
 	 * This only cleans the local cache in WP_Object_Cache, without

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -603,6 +603,354 @@ class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Clean up orphaned files in S3 that are not referenced by any WordPress attachments.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--path=<path>]
+	 * : The path to check for orphaned files. Defaults to wp-content/uploads.
+	 *
+	 * [--delete]
+	 * : Whether to delete the orphaned files from S3.
+	 * By default, this command only shows what would be deleted.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Check for orphaned files in the default uploads directory
+	 *     $ wp s3-media cleanup
+	 *
+	 *     # Delete orphaned files from a specific directory
+	 *     $ wp s3-media cleanup --path=wp-content/uploads/2025/03 --delete
+	 */
+	public function cleanup( $args, $assoc_args ) {
+		global $wpdb;
+		
+		$path = isset( $assoc_args['path'] ) ? $assoc_args['path'] : 'wp-content/uploads';
+		$delete = isset( $assoc_args['delete'] );
+		
+		// Get the S3 client and bucket info
+		$s3 = $this->get_s3_media_sync();
+		$s3_client = $s3->get_s3_client();
+		$bucket = $s3->get_s3_bucket();
+		$bucket_parts = explode( '/', $bucket, 2 );
+		$bucket_name = $bucket_parts[0];
+		$prefix = isset( $bucket_parts[1] ) ? trailingslashit( $bucket_parts[1] ) : '';
+		
+		// Full prefix for S3 listing
+		$full_prefix = trailingslashit( $prefix . $path );
+		
+		WP_CLI::line( sprintf( 'Scanning S3 bucket "%s" with prefix "%s"', $bucket_name, $full_prefix ) );
+		
+		// Get list of files from S3
+		$s3_files = array();
+		$marker = '';
+		$continue = true;
+		$total_files = 0;
+		
+		WP_CLI::line( 'Retrieving file list from S3...' );
+		
+		while ( $continue && $total_files < 1000 ) {
+			try {
+				$params = array(
+					'Bucket' => $bucket_name,
+					'Prefix' => $full_prefix,
+					'MaxKeys' => min( 1000, 1000 - $total_files ),
+				);
+				
+				if ( ! empty( $marker ) ) {
+					$params['Marker'] = $marker;
+				}
+				
+				$objects = $s3_client->listObjects( $params );
+				
+				if ( empty( $objects['Contents'] ) ) {
+					$continue = false;
+					continue;
+				}
+				
+				foreach ( $objects['Contents'] as $object ) {
+					$key = $object['Key'];
+					
+					// Skip directory objects (keys ending with /)
+					if ( substr( $key, -1 ) === '/' ) {
+						continue;
+					}
+					
+					// Remove the bucket prefix to get the relative path
+					$relative_key = substr( $key, strlen( $prefix ) );
+					$s3_files[ $relative_key ] = array(
+						'key' => $key,
+						'size' => $object['Size'],
+						'last_modified' => $object['LastModified'],
+					);
+					
+					$total_files++;
+				}
+				
+				// Set marker for next batch
+				if ( $objects['IsTruncated'] && isset( $objects['NextMarker'] ) ) {
+					$marker = $objects['NextMarker'];
+				} elseif ( $objects['IsTruncated'] && ! empty( $objects['Contents'] ) ) {
+					$last = end( $objects['Contents'] );
+					$marker = $last['Key'];
+				} else {
+					$continue = false;
+				}
+				
+			} catch ( \Exception $e ) {
+				WP_CLI::error( sprintf( 'Failed to list objects from S3: %s', $e->getMessage() ) );
+				return;
+			}
+		}
+		
+		if ( empty( $s3_files ) ) {
+			WP_CLI::success( 'No files found in the specified S3 path.' );
+			return;
+		}
+		
+		WP_CLI::line( sprintf( 'Found %d files in S3', count( $s3_files ) ) );
+		
+		// Get uploads directory info
+		$uploads = wp_upload_dir();
+		$uploads_url = $uploads['baseurl'];
+		$uploads_path = 'wp-content/uploads';
+		
+		// Now check which files exist in WordPress
+		$orphaned_files = array();
+		
+		WP_CLI::line( '' );
+		WP_CLI::line( 'Checking WordPress attachments...' );
+		
+		// Initialize progress bar for total files
+		$progress = \WP_CLI\Utils\make_progress_bar( 'Progress', count( $s3_files ) );
+		$total_processed = 0;
+		
+		// Batch process the files to avoid memory issues
+		$batch_size = 100;
+		$batches = array_chunk( array_keys( $s3_files ), $batch_size, true );
+		
+		foreach ( $batches as $batch ) {
+			// Filter out files that wouldn't be in WordPress uploads
+			$wp_check_files = array();
+			
+			foreach ( $batch as $relative_key ) {
+				// Skip if not in uploads directory
+				if ( strpos( $relative_key, $uploads_path ) !== 0 ) {
+					continue;
+				}
+				
+				// Get the file path relative to uploads dir
+				$file_path = substr( $relative_key, strlen( $uploads_path ) );
+				$file_path = ltrim( $file_path, '/' );
+				
+				// Normalize the path - replace spaces with hyphens and clean special characters
+				$normalized_path = preg_replace('/\s+/', '-', $file_path);
+				$normalized_path = sanitize_file_name($normalized_path);
+				
+				// Skip certain file patterns like temporary files
+				if ( preg_match( '/-e\d+\.|-\d+x\d+\./', $normalized_path ) ) {
+					// These are typically WordPress-generated temporary files
+					// Consider them orphaned by default
+					$orphaned_files[ $relative_key ] = $s3_files[ $relative_key ];
+					continue;
+				}
+				
+				$wp_check_files[ $relative_key ] = $normalized_path;
+			}
+			
+			// Skip to next batch if no files to check
+			if ( empty( $wp_check_files ) ) {
+				foreach ( $batch as $relative_key ) {
+					$progress->tick();
+				}
+				continue;
+			}
+			
+			// First try exact matches
+			$placeholders = implode( ',', array_fill( 0, count( $wp_check_files ), '%s' ) );
+			$query = $wpdb->prepare(
+				"SELECT meta_value FROM {$wpdb->postmeta} 
+				WHERE meta_key = '_wp_attached_file'",
+				array()
+			);
+			
+			$results = $wpdb->get_col( $query );
+			$found_files = array();
+			
+			// Normalize the results
+			foreach ( $results as $file ) {
+				// WordPress stores paths without wp-content/uploads prefix
+				// Store both with and without prefix for comparison
+				$found_files[ $file ] = true;
+				$found_files[ $uploads_path . '/' . ltrim( $file, '/' ) ] = true;
+				
+				// Also store normalized versions
+				$normalized = preg_replace('/\s+/', '-', $file);
+				$normalized = sanitize_file_name($normalized);
+				$found_files[ $normalized ] = true;
+				$found_files[ $uploads_path . '/' . ltrim( $normalized, '/' ) ] = true;
+			}
+			
+			// Check which files are orphaned
+			foreach ( $wp_check_files as $relative_key => $file_path ) {
+				$check_path = substr( $relative_key, strlen( $uploads_path . '/' ) );
+				if ( ! isset( $found_files[ $check_path ] ) && ! isset( $found_files[ $relative_key ] ) ) {
+					$orphaned_files[ $relative_key ] = $s3_files[ $relative_key ];
+				}
+				$progress->tick();
+				$total_processed++;
+			}
+			
+			// Update progress for any skipped files in this batch
+			foreach ( $batch as $relative_key ) {
+				if ( ! isset( $wp_check_files[ $relative_key ] ) ) {
+					$progress->tick();
+					$total_processed++;
+				}
+			}
+		}
+		
+		$progress->finish();
+		
+		// Display results
+		WP_CLI::line( '' );
+		WP_CLI::line( sprintf( 'Found %d orphaned files in S3', count( $orphaned_files ) ) );
+		
+		if ( empty( $orphaned_files ) ) {
+			WP_CLI::success( 'No orphaned files to clean up.' );
+			return;
+		}
+		
+		// Group by year/month for better reporting
+		$grouped_files = array();
+		$total_size = 0;
+		
+		foreach ( $orphaned_files as $relative_key => $file_info ) {
+			// Extract year/month from path
+			$matches = array();
+			if ( preg_match( '|/(\d{4})/(\d{2})/|', $relative_key, $matches ) ) {
+				$group = $matches[1] . '/' . $matches[2];
+			} else {
+				$group = 'other';
+			}
+			
+			if ( ! isset( $grouped_files[ $group ] ) ) {
+				$grouped_files[ $group ] = array(
+					'count' => 0,
+					'size' => 0,
+					'files' => array(),
+				);
+			}
+			
+			$grouped_files[ $group ]['count']++;
+			$grouped_files[ $group ]['size'] += $file_info['size'];
+			$grouped_files[ $group ]['files'][] = $relative_key;
+			$total_size += $file_info['size'];
+		}
+		
+		// Display summary by group
+		$table_data = array();
+		foreach ( $grouped_files as $group => $info ) {
+			$table_data[] = array(
+				'Group' => $group,
+				'Count' => $info['count'],
+				'Size' => size_format( $info['size'], 2 ),
+			);
+		}
+		
+		// Add total row
+		$table_data[] = array(
+			'Group' => 'TOTAL',
+			'Count' => count( $orphaned_files ),
+			'Size' => size_format( $total_size, 2 ),
+		);
+		
+		WP_CLI\Utils\format_items( 'table', $table_data, array( 'Group', 'Count', 'Size' ) );
+		
+		// List some example files
+		$examples = array_slice( array_keys( $orphaned_files ), 0, 10 );
+		WP_CLI::line( '' );
+		WP_CLI::line( 'Example orphaned files:' );
+		foreach ( $examples as $example ) {
+			WP_CLI::line( ' - ' . $example );
+		}
+		
+		// If there are more files than shown in the examples
+		if ( count( $orphaned_files ) > count( $examples ) ) {
+			WP_CLI::line( sprintf( '... and %d more', count( $orphaned_files ) - count( $examples ) ) );
+		}
+		
+		// Delete orphaned files if requested
+		if ( $delete ) {
+			WP_CLI::line( '' );
+			WP_CLI::line( '----------------------------------------' );
+			WP_CLI::line( 'DANGER: You are about to delete files!' );
+			WP_CLI::line( '----------------------------------------' );
+			WP_CLI::confirm( sprintf( 'Are you sure you want to delete %d orphaned files from S3?', count( $orphaned_files ) ) );
+			
+			$progress = \WP_CLI\Utils\make_progress_bar( 'Deleting orphaned files', count( $orphaned_files ) );
+			$delete_count = 0;
+			$failed_count = 0;
+			
+			// Process in batches of 1000 (maximum for S3 deleteObjects)
+			$delete_batches = array_chunk( array_keys( $orphaned_files ), 1000 );
+			
+			foreach ( $delete_batches as $batch ) {
+				$objects = array();
+				
+				foreach ( $batch as $relative_key ) {
+					$objects[] = array(
+						'Key' => $orphaned_files[ $relative_key ]['key'],
+					);
+				}
+				
+				try {
+					$result = $s3_client->deleteObjects([
+						'Bucket' => $bucket_name,
+						'Delete' => [
+							'Objects' => $objects,
+							'Quiet' => true,
+						],
+					]);
+					
+					$delete_count += count( $objects );
+					
+					if ( ! empty( $result['Errors'] ) ) {
+						$failed_count += count( $result['Errors'] );
+						foreach ( $result['Errors'] as $error ) {
+							WP_CLI::warning( sprintf( 'Failed to delete %s: %s', $error['Key'], $error['Message'] ) );
+						}
+					}
+					
+				} catch ( \Exception $e ) {
+					WP_CLI::error( sprintf( 'Error deleting objects: %s', $e->getMessage() ) );
+					return;
+				}
+				
+				// Update progress
+				foreach ( $batch as $relative_key ) {
+					$progress->tick();
+				}
+			}
+			
+			$progress->finish();
+			
+			WP_CLI::success( sprintf( 'Successfully deleted %d orphaned files from S3', $delete_count ) );
+			
+			if ( $failed_count > 0 ) {
+				WP_CLI::warning( sprintf( 'Failed to delete %d files', $failed_count ) );
+			}
+		} else {
+			WP_CLI::line( '' );
+			WP_CLI::line( '----------------------------------------' );
+			WP_CLI::line( 'DRY RUN - No files will be deleted' );
+			WP_CLI::line( '----------------------------------------' );
+			WP_CLI::line( 'To delete these orphaned files, run this command with the --delete flag:' );
+			WP_CLI::line( 'wp s3-media cleanup --path=' . $path . ' --delete' );
+		}
+	}
+
+	/**
 	 * Reset the local WordPress object cache.
 	 *
 	 * This only cleans the local cache in WP_Object_Cache, without

--- a/inc/class-s3-media-sync-wp-cli.php
+++ b/inc/class-s3-media-sync-wp-cli.php
@@ -1,6 +1,8 @@
 <?php
 
-use \WP_CLI\Utils;
+use WP_CLI;
+use WP_CLI\Utils;
+use WP_CLI_Command;
 
 /**
  * Class S3_Media_Sync_WP_CLI_Command
@@ -38,7 +40,7 @@ class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 	public function upload( $args, $assoc_args ) {
 		// Get the source and destination and initialize some concurrency variables
 		$from	= wp_get_upload_dir();
-		$to	= S3_Media_Sync::init()->get_s3_bucket_url();
+		$to	= $this->get_s3_media_sync()->get_s3_bucket_url();
 		
 		$attachment_id = absint( $args[0] );
 	
@@ -120,7 +122,7 @@ class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 
 		// Get the source and destination and initialize some concurrency variables
 		$from    = wp_get_upload_dir();
-		$to      = S3_Media_Sync::init()->get_s3_bucket_url();
+		$to      = $this->get_s3_media_sync()->get_s3_bucket_url();
 		$offset  = 0;
 		$threads = 10;
 		$limit   = 500;
@@ -222,8 +224,8 @@ class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 	 *     $ wp s3-media rm path/to/files --regex='.*\.jpg'
 	 */
 	public function rm( $args, $args_assoc ) {
-		$s3     = S3_Media_Sync::init()->s3();
-		$bucket = S3_Media_Sync::init()->get_s3_bucket();
+		$s3     = $this->get_s3_media_sync()->get_s3_client();
+		$bucket = $this->get_s3_media_sync()->get_s3_bucket();
 		$prefix = '';
 
 		if ( strpos( $bucket, '/' ) ) {
@@ -292,6 +294,20 @@ class S3_Media_Sync_WP_CLI_Command extends WP_CLI_Command {
 		global $wpdb;
 
 		$wpdb->queries = array();
+	}
+
+	/**
+	 * Get the S3 Media Sync instance.
+	 *
+	 * @return S3_Media_Sync
+	 */
+	private function get_s3_media_sync() {
+		$settings_handler = new S3_Media_Sync_Settings();
+		$settings = $settings_handler->get_settings();
+		$tester = new S3_Media_Sync_Tester($settings);
+		$s3_media_sync = new S3_Media_Sync($settings_handler);
+		$s3_media_sync->setup();
+		return $s3_media_sync;
 	}
 
 }

--- a/inc/class-s3-media-sync.php
+++ b/inc/class-s3-media-sync.php
@@ -41,6 +41,13 @@ class S3_Media_Sync {
 		return 's3://' . $this->bucket->get_name();
 	}
 
+	/**
+	 * Get the S3 client instance.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return \Aws\S3\S3Client|null The S3 client, or null if not initialized.
+	 */
 	public function get_s3_client() {
 		return $this->s3_client;
 	}

--- a/inc/class-s3-media-sync.php
+++ b/inc/class-s3-media-sync.php
@@ -41,6 +41,10 @@ class S3_Media_Sync {
 		return 's3://' . $this->bucket->get_name();
 	}
 
+	public function get_s3_client() {
+		return $this->s3_client;
+	}
+
 	/**
 	 * Setup for the plugin
 	 */
@@ -60,8 +64,8 @@ class S3_Media_Sync {
 		try {
 			// Register and configure the stream wrapper
 			$factory = $this->get_client_factory();
-			$s3_client = $factory->create($this->settings);
-			$factory->configure_stream_wrapper($s3_client, $this->bucket);
+			$this->s3_client = $factory->create($this->settings);
+			$factory->configure_stream_wrapper($this->s3_client, $this->bucket);
 
 			// Hook into WordPress media handling
 			// These hooks match the original plugin behavior and test expectations

--- a/inc/class-s3-media-sync.php
+++ b/inc/class-s3-media-sync.php
@@ -312,6 +312,30 @@ class S3_Media_Sync {
 			// Ensure we have a fresh S3 client
 			$factory = $this->get_client_factory();
 			$s3_client = $factory->create($this->settings);
+			
+			// Check if bucket allows ACLs BEFORE configuring stream wrapper
+			if (isset($this->settings['use_acl']) && $this->settings['use_acl']) {
+				try {
+					$result = $s3_client->getBucketOwnershipControls([
+						'Bucket' => $this->settings['bucket']
+					]);
+					
+					if (isset($result['OwnershipControls']['Rules'][0]['ObjectOwnership']) && 
+						$result['OwnershipControls']['Rules'][0]['ObjectOwnership'] === 'BucketOwnerEnforced') {
+						// Bucket doesn't allow ACLs - update settings
+						error_log('S3 Media Sync: Bucket does not allow ACLs - disabling ACL setting');
+						$this->settings['use_acl'] = false;
+						update_option('s3_media_sync_settings', $this->settings);
+					}
+				} catch (\Exception $e) {
+					error_log('S3 Media Sync: Could not determine bucket ACL settings: ' . $e->getMessage());
+					// If we can't check, disable ACLs to be safe
+					$this->settings['use_acl'] = false;
+					update_option('s3_media_sync_settings', $this->settings);
+				}
+			}
+			
+			// Now configure stream wrapper with updated settings
 			$factory->configure_stream_wrapper($s3_client, $this->bucket);
 			
 			$wp_uploads = wp_upload_dir();

--- a/s3-media-sync.php
+++ b/s3-media-sync.php
@@ -17,8 +17,9 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 }
 
-if ( defined( 'WP_CLI' ) && class_exists( 'WPCOM_VIP_CLI_Command' ) ) {
+if ( defined( 'WP_CLI' ) ) {
 	require_once dirname( __FILE__ ) . '/inc/class-s3-media-sync-wp-cli.php';
+	WP_CLI::add_command( 's3-media', 'S3_Media_Sync_WP_CLI_Command' );
 }
 
 // Initialize the plugin with dependencies

--- a/tests/Integration/S3ClientTest.php
+++ b/tests/Integration/S3ClientTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Integration tests for S3 client functionality
+ *
+ * @package S3_Media_Sync
+ */
+
+declare( strict_types=1 );
+
+namespace S3_Media_Sync\Tests\Integration;
+
+use Aws\S3\S3Client;
+use S3_Media_Sync\Tests\TestCase;
+
+/**
+ * Test case for S3 client functionality.
+ *
+ * @group integration
+ * @group s3-client
+ * @covers \S3_Media_Sync
+ * @uses \S3_Media_Sync_Settings
+ * @uses \S3_Media_Sync_Stream_Wrapper
+ * @uses \S3_Media_Sync\Value_Objects\Region
+ * @uses \S3_Media_Sync\Value_Objects\S3_Bucket
+ */
+class S3ClientTest extends TestCase {
+
+	/**
+	 * Test that get_s3_client returns null before setup is called.
+	 *
+	 * @covers \S3_Media_Sync::get_s3_client
+	 */
+	public function test_get_s3_client_returns_null_before_setup(): void {
+		// Create a new instance without calling setup
+		$settings_handler = new \S3_Media_Sync_Settings();
+		$settings_handler->update_settings( $this->default_settings );
+		$s3_media_sync = new \S3_Media_Sync( $settings_handler );
+
+		// Client should be null before setup
+		$this->assertNull( $s3_media_sync->get_s3_client() );
+	}
+
+	/**
+	 * Test that get_s3_client returns the S3 client after setup.
+	 *
+	 * @covers \S3_Media_Sync::get_s3_client
+	 */
+	public function test_get_s3_client_returns_client_after_setup(): void {
+		// Create mock client
+		$this->create_mock_s3_client();
+
+		// Setup the plugin
+		$this->s3_media_sync->setup();
+
+		// Client should be set after setup
+		$client = $this->s3_media_sync->get_s3_client();
+		$this->assertNotNull( $client );
+	}
+
+	/**
+	 * Test that S3_Media_Sync throws exception with invalid settings.
+	 *
+	 * Note: Currently the constructor throws an exception when settings are invalid.
+	 * This test documents that behavior - see issue #47 for graceful handling.
+	 *
+	 * @covers \S3_Media_Sync::__construct
+	 */
+	public function test_constructor_throws_with_invalid_region(): void {
+		$this->expectException( \S3_Media_Sync\Exceptions\Invalid_Region_Exception::class );
+
+		// Create instance with empty settings - should throw
+		$settings_handler = new \S3_Media_Sync_Settings();
+		$settings_handler->update_settings( [
+			'bucket' => '',
+			'key'    => '',
+			'secret' => '',
+			'region' => '',
+		] );
+
+		// This should throw an exception
+		new \S3_Media_Sync( $settings_handler );
+	}
+
+	/**
+	 * Test that get_s3_bucket returns the configured bucket name.
+	 *
+	 * @covers \S3_Media_Sync::get_s3_bucket
+	 */
+	public function test_get_s3_bucket_returns_bucket_name(): void {
+		$bucket = $this->s3_media_sync->get_s3_bucket();
+		$this->assertSame( 'test-bucket', $bucket );
+	}
+
+	/**
+	 * Test that get_s3_bucket_url returns the S3 URL.
+	 *
+	 * @covers \S3_Media_Sync::get_s3_bucket_url
+	 */
+	public function test_get_s3_bucket_url_returns_s3_url(): void {
+		$url = $this->s3_media_sync->get_s3_bucket_url();
+		$this->assertSame( 's3://test-bucket', $url );
+	}
+
+	/**
+	 * Test that get_settings_handler returns the settings handler.
+	 *
+	 * @covers \S3_Media_Sync::get_settings_handler
+	 */
+	public function test_get_settings_handler_returns_handler(): void {
+		$handler = $this->s3_media_sync->get_settings_handler();
+		$this->assertInstanceOf( \S3_Media_Sync_Settings::class, $handler );
+	}
+
+	/**
+	 * Test that get_settings_handler can retrieve settings.
+	 *
+	 * @covers \S3_Media_Sync::get_settings_handler
+	 */
+	public function test_get_settings_handler_can_retrieve_settings(): void {
+		$handler  = $this->s3_media_sync->get_settings_handler();
+		$settings = $handler->get_settings();
+
+		$this->assertSame( 'test-bucket', $settings['bucket'] );
+		$this->assertSame( 'us-east-1', $settings['region'] );
+	}
+}

--- a/tests/Integration/WPCLICommandTest.php
+++ b/tests/Integration/WPCLICommandTest.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Integration tests for WP-CLI commands
+ *
+ * @package S3_Media_Sync
+ */
+
+declare( strict_types=1 );
+
+namespace S3_Media_Sync\Tests\Integration;
+
+use S3_Media_Sync\Tests\TestCase;
+
+/**
+ * Test case for WP-CLI command functionality.
+ *
+ * Note: These tests verify the command class structure and helper methods.
+ * Full CLI testing would require the WP-CLI test framework.
+ *
+ * @group integration
+ * @group wp-cli
+ * @covers \S3_Media_Sync_WP_CLI_Command
+ * @uses \S3_Media_Sync
+ * @uses \S3_Media_Sync_Settings
+ * @uses \S3_Media_Sync_Stream_Wrapper
+ * @uses \S3_Media_Sync\Value_Objects\Region
+ * @uses \S3_Media_Sync\Value_Objects\S3_Bucket
+ */
+class WPCLICommandTest extends TestCase {
+
+	/**
+	 * Set up the test.
+	 *
+	 * Load the WP-CLI command file if WP-CLI is available.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// The WP-CLI command class is excluded from autoload and only loaded when WP-CLI is defined.
+		// For testing, we need to manually load it if WP-CLI is available.
+		if ( defined( 'WP_CLI' ) && ! class_exists( 'S3_Media_Sync_WP_CLI_Command' ) ) {
+			require_once dirname( __DIR__, 2 ) . '/inc/class-s3-media-sync-wp-cli.php';
+		}
+	}
+
+	/**
+	 * Skip test if WP-CLI is not available.
+	 */
+	private function skip_if_no_wp_cli(): void {
+		if ( ! defined( 'WP_CLI' ) || ! class_exists( 'S3_Media_Sync_WP_CLI_Command' ) ) {
+			$this->markTestSkipped( 'WP-CLI is not available in this test environment.' );
+		}
+	}
+
+	/**
+	 * Test that the WP-CLI command class exists when WP-CLI is available.
+	 */
+	public function test_wp_cli_command_class_exists(): void {
+		$this->skip_if_no_wp_cli();
+
+		$this->assertTrue(
+			class_exists( 'S3_Media_Sync_WP_CLI_Command' ),
+			'S3_Media_Sync_WP_CLI_Command class should exist'
+		);
+	}
+
+	/**
+	 * Test that the WP-CLI command extends WP_CLI_Command.
+	 */
+	public function test_wp_cli_command_extends_correct_parent(): void {
+		$this->skip_if_no_wp_cli();
+
+		$reflection = new \ReflectionClass( 'S3_Media_Sync_WP_CLI_Command' );
+		$parent     = $reflection->getParentClass();
+
+		$this->assertNotFalse( $parent, 'S3_Media_Sync_WP_CLI_Command should have a parent class' );
+		$this->assertSame( 'WP_CLI_Command', $parent->getName() );
+	}
+
+	/**
+	 * Test that all expected public methods exist.
+	 */
+	public function test_wp_cli_command_has_expected_methods(): void {
+		$this->skip_if_no_wp_cli();
+
+		$expected_methods = [
+			'upload',
+			'upload_all',
+			'rm',
+			'status',
+			'verify',
+			'cleanup',
+		];
+
+		foreach ( $expected_methods as $method ) {
+			$this->assertTrue(
+				method_exists( 'S3_Media_Sync_WP_CLI_Command', $method ),
+				"S3_Media_Sync_WP_CLI_Command should have the '{$method}' method"
+			);
+		}
+	}
+
+	/**
+	 * Test that the status command method has correct visibility.
+	 */
+	public function test_status_method_is_public(): void {
+		$this->skip_if_no_wp_cli();
+
+		$reflection = new \ReflectionMethod( 'S3_Media_Sync_WP_CLI_Command', 'status' );
+		$this->assertTrue( $reflection->isPublic(), 'status method should be public' );
+	}
+
+	/**
+	 * Test that the verify command method has correct visibility.
+	 */
+	public function test_verify_method_is_public(): void {
+		$this->skip_if_no_wp_cli();
+
+		$reflection = new \ReflectionMethod( 'S3_Media_Sync_WP_CLI_Command', 'verify' );
+		$this->assertTrue( $reflection->isPublic(), 'verify method should be public' );
+	}
+
+	/**
+	 * Test that the cleanup command method has correct visibility.
+	 */
+	public function test_cleanup_method_is_public(): void {
+		$this->skip_if_no_wp_cli();
+
+		$reflection = new \ReflectionMethod( 'S3_Media_Sync_WP_CLI_Command', 'cleanup' );
+		$this->assertTrue( $reflection->isPublic(), 'cleanup method should be public' );
+	}
+
+	/**
+	 * Test that helper methods are private.
+	 */
+	public function test_helper_methods_are_private(): void {
+		$this->skip_if_no_wp_cli();
+
+		$private_methods = [
+			'reset_local_object_cache',
+			'reset_db_query_log',
+			'get_s3_media_sync',
+			'upload_file_to_s3',
+		];
+
+		foreach ( $private_methods as $method ) {
+			$reflection = new \ReflectionMethod( 'S3_Media_Sync_WP_CLI_Command', $method );
+			$this->assertTrue(
+				$reflection->isPrivate(),
+				"{$method} method should be private"
+			);
+		}
+	}
+
+	/**
+	 * Test that get_s3_media_sync helper returns S3_Media_Sync instance.
+	 */
+	public function test_get_s3_media_sync_returns_correct_type(): void {
+		$this->skip_if_no_wp_cli();
+
+		// Create mock client first
+		$this->create_mock_s3_client();
+
+		// Use reflection to access private method
+		$command    = new \S3_Media_Sync_WP_CLI_Command();
+		$reflection = new \ReflectionMethod( $command, 'get_s3_media_sync' );
+		$reflection->setAccessible( true );
+
+		$result = $reflection->invoke( $command );
+
+		$this->assertInstanceOf( \S3_Media_Sync::class, $result );
+	}
+
+	/**
+	 * Test that S3_Media_Sync instance from helper has working methods.
+	 */
+	public function test_s3_media_sync_from_helper_has_working_methods(): void {
+		$this->skip_if_no_wp_cli();
+
+		// Create mock client first
+		$this->create_mock_s3_client();
+
+		// Use reflection to access private method
+		$command    = new \S3_Media_Sync_WP_CLI_Command();
+		$reflection = new \ReflectionMethod( $command, 'get_s3_media_sync' );
+		$reflection->setAccessible( true );
+
+		$s3_media_sync = $reflection->invoke( $command );
+
+		// Test that we can get the bucket
+		$this->assertSame( 'test-bucket', $s3_media_sync->get_s3_bucket() );
+
+		// Test that we can get the bucket URL
+		$this->assertSame( 's3://test-bucket', $s3_media_sync->get_s3_bucket_url() );
+
+		// Test that we can get the settings handler
+		$this->assertInstanceOf( \S3_Media_Sync_Settings::class, $s3_media_sync->get_settings_handler() );
+	}
+
+	/**
+	 * Test that reset_db_query_log clears the query log.
+	 */
+	public function test_reset_db_query_log_clears_queries(): void {
+		$this->skip_if_no_wp_cli();
+
+		global $wpdb;
+
+		// Add some fake queries to the log
+		$wpdb->queries = [
+			[ 'SELECT 1', 0.001, 'test' ],
+			[ 'SELECT 2', 0.002, 'test' ],
+		];
+
+		// Use reflection to access private method
+		$command    = new \S3_Media_Sync_WP_CLI_Command();
+		$reflection = new \ReflectionMethod( $command, 'reset_db_query_log' );
+		$reflection->setAccessible( true );
+
+		$reflection->invoke( $command );
+
+		$this->assertEmpty( $wpdb->queries, 'Query log should be empty after reset' );
+	}
+}


### PR DESCRIPTION
Add `status`, `verify`, and `cleanup` WP-CLI commands.

Generally working, but want to double-check it all. It could also do with some Behat tests.

I'd like to try and minimise the amount of work that each command is doing, and centralise it into the same service classes that are triggered from the UI, too.