### PR TITLE
Increase minimum supported WordPress version to 6.4

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php: [8.1, 8.3]
-        wordpress: [5.9, latest]
+        wordpress: [6.4, latest]
 
     steps:
     - name: Install SVN (Subversion)

--- a/s3-media-sync.php
+++ b/s3-media-sync.php
@@ -2,11 +2,12 @@
 /**
  * Plugin Name: S3 Media Sync
  * Description: Sync full media backups to S3.
- * Author: Alexis Kulash, WordPress VIP
+ * Version: 1.4.1
+ * Requires at least: 6.4
  * Requires PHP: 8.1
+ * Author: Alexis Kulash, WordPress VIP
  * Text Domain: s3-media-sync
  * Domain Path: /languages/
- * Version: 1.4.1
  */
 
 define( 'S3_MEDIA_SYNC_FILE', __FILE__ );


### PR DESCRIPTION
## Summary

Bumps the minimum required WordPress version to 6.4.

## Why

WordPress 6.4 provides a more modern baseline, with 85.1% of WordPress sites running 6.4 or later. WP 6.4 drops support for PHP 5.6, aligning with current PHP support policies.

## Testing

No functional changes - this only updates metadata and code standards configuration.