### PR TITLE
chore: migrate dependabot reviewers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# The following teams will get auto-tagged for a review.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @Automattic/vip-plugins

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
         patterns: ["*"]
     labels:
       - "dependencies"
-    reviewers:
-      - "Automattic/vip-plugins"
     commit-message:
       prefix: "Actions"
       include: "scope"
@@ -40,8 +38,6 @@ updates:
           - "mockery/*"
     labels:
       - "dependencies"
-    reviewers:
-      - "Automattic/vip-plugins"
     commit-message:
       prefix: "Composer"
       include: "scope"
@@ -63,8 +59,6 @@ updates:
           - "@types/*"
     labels:
       - "dependencies"
-    reviewers:
-      - "Automattic/vip-plugins"
     commit-message:
       prefix: "npm"
       include: "scope"


### PR DESCRIPTION
## Summary
- Add CODEOWNERS file to automatically assign @Automattic/vip-plugins as reviewers for all PRs
- Remove reviewers from dependabot.yml (now handled by CODEOWNERS)

See: https://github.com/dependabot/codeowner-migration-action

🤖 Generated with [Claude Code](https://claude.com/claude-code)