### PR TITLE
ci: standardise test matrix and update readme

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -49,7 +49,7 @@ jobs:
             php: 'latest'
 
     env:
-      WP_ENV_CORE: ${{ matrix.wordpress == 'master' && 'WordPress/WordPress#master' || format('https://wordpress.org/wordpress-{0}.zip', matrix.wordpress) }}
+      WP_ENV_CORE: WordPress/WordPress#${{ matrix.wordpress }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -35,36 +35,20 @@ jobs:
   integration-tests:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}${{ matrix.multisite && ' (MS)' || '' }}
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.allowed_failure }}
     timeout-minutes: 20
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Check lowest supported WP version with lowest supported PHP.
+          # Check lowest supported WP version, with the lowest supported PHP.
           - wordpress: '6.4'
             php: '8.1'
-            multisite: false
-            allowed_failure: false
-          # Check latest WP with the highest supported PHP.
-          - wordpress: '6.9'
-            php: '8.4'
-            multisite: false
-            allowed_failure: false
-          # Check latest WP multisite.
-          - wordpress: '6.9'
-            php: '8.4'
-            multisite: true
-            allowed_failure: false
-          # Check upcoming WP.
+          # Check latest WP with the latest PHP.
           - wordpress: 'master'
-            php: '8.4'
-            multisite: false
-            allowed_failure: true
+            php: 'latest'
 
     env:
-      WP_ENV_PHP_VERSION: ${{ matrix.php }}
       WP_ENV_CORE: ${{ matrix.wordpress == 'master' && 'WordPress/WordPress#master' || format('https://wordpress.org/wordpress-{0}.zip', matrix.wordpress) }}
 
     steps:

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,7 @@
   "plugins": [
     "."
   ],
-  "phpVersion": "8.1",
+  "phpVersion": "8.4",
   "config": {
     "WP_DEBUG": true,
     "WP_DEBUG_LOG": true,

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # S3 Media Sync
 
+Stable tag: 1.4.1
+Requires at least: 6.4
+Tested up to: 6.9
+Requires PHP: 8.1
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Tags: s3, aws, media, sync, cloud storage
+Contributors: alexiskulash, automattic, wpcomvip
+
 A WordPress plugin that syncs media uploads to Amazon S3, providing reliable cloud storage for your WordPress media library.
 
 ## Overview


### PR DESCRIPTION
## Summary

- Updates CI workflow to test against WP 6.4 and master with PHP 8.1 and latest
- Removes allowed_failure flag and multisite matrix entries to simplify the test matrix
- Adds standard plugin header fields to README including tested versions (WP 6.9)

## Test plan

- [ ] CI passes on WP 6.4 with PHP 8.1
- [ ] CI passes on WP master with PHP latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)