### PR TITLE
Standardise Composer script names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,8 @@
 			"@putenv XDEBUG_MODE=coverage",
 			"./vendor/bin/phpunit --testsuite integration --coverage-text --coverage-html build/coverage"
 		],
-		"cs": "phpcs",
-		"cbf": "phpcbf",
+		"cs": "@php ./vendor/bin/phpcs",
+		"cs-fix": "@php ./vendor/bin/phpcbf",
 		"i18n": [
 			"@php wp i18n make-pot . ./languages/s3-media-sync.pot"
 		],
@@ -68,7 +68,7 @@
 	"scripts-descriptions": {
 		"coverage": "Run tests with code coverage reporting",
 		"cs": "Run PHP CodeSniffer to check code style",
-		"cbf": "Run PHP CodeSniffer to fix code style issues",
+		"cs-fix": "Run PHP Code Beautifier to auto-fix code style issues",
 		"i18n": "Generate a POT file for translation",
 		"lint": "Run PHP parallel lint to check for syntax errors",
 		"test": "Run all tests for the S3 Media Sync plugin.",

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,11 +47,11 @@ composer test
 This plugin follows the WordPress coding standards. To check your code for standards compliance, run:
 
 ```sh
-composer phpcs
+composer cs
 ```
 
 To automatically fix many common coding standards issues:
 
 ```sh
-composer phpcbf
+composer cs-fix
 ``` 


### PR DESCRIPTION
## Summary

Our Composer scripts for code style checking and auto-fixing used
non-standard names (`cs` calling `phpcs` directly, `cbf` calling
`phpcbf`), which diverged from the conventions defined in
plugin-standards. Developers working across multiple plugins shouldn't
need to remember different command names for the same operation.

This renames `cbf` to `cs-fix` and updates both scripts to use the
`@php ./vendor/bin/` prefix, aligning with the standard script
definitions. The development documentation is also updated to reference
the canonical `composer cs` and `composer cs-fix` aliases rather than
calling the binaries directly.

## Test plan

- [ ] Run `composer cs` — confirms PHPCS executes correctly
- [ ] Run `composer cs-fix` — confirms PHPCBF executes correctly
- [ ] Run `composer run --list` — confirms both scripts appear with descriptions