### PR TITLE
Skip Composer audit during release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           tools: composer
 
       - name: Install production Composer dependencies
-        run: composer install --no-dev --prefer-dist --no-progress --optimize-autoloader
+        run: composer install --no-dev --no-audit --prefer-dist --no-progress --optimize-autoloader
 
       - name: Extract changelog for release notes
         if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

Composer 2.8+ blocks installation of packages with known security advisories by default. When the release workflow runs against older tags like 1.3.0 (which pins `aws/aws-sdk-php` to `~3.288.1`), the build fails because that SDK version is flagged.

Adding `--no-audit` is appropriate here since we are building historical releases as they were, not adopting insecure dependencies. The SDK has already been updated on `develop`.

## Test plan

- [ ] Merge, then dispatch the release workflow for tags `1.3.0`, `1.4.0`, and `1.4.1` — all three should build successfully