### PR TITLE
Use env vars to skip Composer audit in release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,10 @@ jobs:
           tools: composer
 
       - name: Install production Composer dependencies
-        run: composer install --no-dev --no-audit --prefer-dist --no-progress --optimize-autoloader
+        run: composer install --no-dev --prefer-dist --no-progress --optimize-autoloader
+        env:
+          COMPOSER_AUDIT_ABANDONED: ignore
+          COMPOSER_NO_AUDIT: 1
 
       - name: Extract changelog for release notes
         if: github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,7 @@ jobs:
           tools: composer
 
       - name: Install production Composer dependencies
-        run: composer install --no-dev --prefer-dist --no-progress --optimize-autoloader
-        env:
-          COMPOSER_AUDIT_ABANDONED: ignore
-          COMPOSER_NO_AUDIT: 1
+        run: composer install --no-dev --no-security-blocking --prefer-dist --no-progress --optimize-autoloader
 
       - name: Extract changelog for release notes
         if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

The previous fix used the `--no-audit` CLI flag, which doesn't exist in the Composer version provided by `shivammathur/setup-php`. This switches to environment variables (`COMPOSER_NO_AUDIT=1` and `COMPOSER_AUDIT_ABANDONED=ignore`) which work across all Composer 2.x versions.

Without this, the release workflow fails when building older tags that pin to AWS SDK versions flagged with security advisories.

## Test plan

- [ ] Merge, then dispatch the release workflow for tag `1.3.0` — should build successfully
- [ ] Repeat for `1.4.0` and `1.4.1`