### PR TITLE
Correct inaccurate version comments on pinned actions

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -58,7 +58,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20
           cache: npm
@@ -67,7 +67,7 @@ jobs:
         run: npm ci
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.34.0
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: ${{ matrix.php }}
           coverage: none


### PR DESCRIPTION
## Summary

The integrations workflow pins its GitHub Actions to full commit SHAs, which is exactly what we want for supply-chain safety. The trailing `# vX.Y.Z` comments, however, exist purely to make those opaque SHAs human-readable, and two of them had drifted away from the release the SHA actually points to.

The `actions/setup-node` pin (`48b55a01…`) was annotated `# v4.4.0` but resolves to tag **v6.4.0**, and the `shivammathur/setup-php` pin (`f3e473d1…`) was annotated `# v2.34.0` but resolves to tag **2.37.2**. The setup-php comment was left stale by a recent Dependabot bump that advanced the SHA without updating its comment. A reviewer trusting those comments would have badly misjudged which versions CI was running, and anyone bumping the pins would have started from the wrong baseline.

This change corrects both comments to match the tags their SHAs genuinely resolve to. Nothing functional changes: the commit SHAs the actions resolve to are untouched, so the workflow runs precisely the same versions it did before, the labels just now tell the truth.